### PR TITLE
Fixing deprecated usage of API

### DIFF
--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -130,7 +130,7 @@ module FluentPluginKinesis
         # :http_wire_trace => true
       end
 
-      @client = Aws::Kinesis.new(options)
+      @client = Aws::Kinesis::Client.new(options)
 
     end
 


### PR DESCRIPTION
Aws::Kinesis.new is deprecated, use Aws::Kinesis::Client.new instead
