### PR TITLE
Fix test

### DIFF
--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -83,7 +83,7 @@ module FluentPluginKinesis
       # http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html
       data = {
         stream_name: @stream_name,
-        data: Base64.encode64(record.to_json),
+        data: Base64.strict_encode64(record.to_json),
         partition_key: get_key(:partition_key,record)
       }
 

--- a/test/plugin/test_out_kinesis.rb
+++ b/test/plugin/test_out_kinesis.rb
@@ -139,12 +139,12 @@ class KinesisOutputTest < Test::Unit::TestCase
 
     d.expect_format({
       'stream_name' => 'test_stream',
-      'data' => Base64.encode64(data1.to_json),
+      'data' => Base64.strict_encode64(data1.to_json),
       'partition_key' => 'key1' }.to_msgpack
     )
     d.expect_format({
       'stream_name' => 'test_stream',
-      'data' => Base64.encode64(data2.to_json),
+      'data' => Base64.strict_encode64(data2.to_json),
       'partition_key' => 'key2' }.to_msgpack
     )
 
@@ -152,12 +152,12 @@ class KinesisOutputTest < Test::Unit::TestCase
     client.describe_stream(stream_name: 'test_stream')
     client.put_record(
       stream_name: 'test_stream',
-      data: Base64.encode64(data1.to_json),
+      data: Base64.strict_encode64(data1.to_json),
       partition_key: 'key1'
     )
     client.put_record(
       stream_name: 'test_stream',
-      data: Base64.encode64(data2.to_json),
+      data: Base64.strict_encode64(data2.to_json),
       partition_key: 'key2'
     )
 
@@ -170,7 +170,7 @@ class KinesisOutputTest < Test::Unit::TestCase
     assert_equal(
         MessagePack.pack({
             "stream_name"       => "test_stream",
-            "data"              => Base64.encode64(data.to_json),
+            "data"              => Base64.strict_encode64(data.to_json),
             "partition_key"     => "key1"
         }),
         d.instance.format('test','test',data)
@@ -194,7 +194,7 @@ class KinesisOutputTest < Test::Unit::TestCase
     assert_equal(
         MessagePack.pack({
             "stream_name"       => "test_stream",
-            "data"              => Base64.encode64(data.to_json),
+            "data"              => Base64.strict_encode64(data.to_json),
             "partition_key"     => "key1",
             "explicit_hash_key" => "hash1"
         }),


### PR DESCRIPTION
- Fix test (test_format  was broken)
  - Add `time` and `tag` to expected record
- Remove the trailing spaces
- Use `strict_encode64` instead of `encode64`
  - `encode64` add LF to every 60 encoded charactors.
