### PR TITLE
Add Kinesis input plugin

### DIFF
--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
+  spec.add_development_dependency "timecop"
 
   spec.add_dependency "fluentd", ">= 0.10.53", "< 0.13"
   spec.add_dependency "aws-sdk-core", ">= 2.0.12", "< 3.0"

--- a/lib/fluent/plugin/in_kinesis.rb
+++ b/lib/fluent/plugin/in_kinesis.rb
@@ -1,0 +1,229 @@
+require 'aws-sdk-core'
+require 'gdbm'
+require 'multi_json'
+require 'logger'
+require 'fluent/plugin/version'
+
+module FluentPluginKinesis
+  class Input < Fluent::Input
+    USER_AGENT_NAME = 'fluent-plugin-kinesis-input'
+
+    STARTING_SEQUENCE_NUMBER_TYPES = %w(
+      AFTER_SEQUENCE_NUMBER
+      AT_SEQUENCE_NUMBER
+    )
+
+    NO_STARTING_SEQUENCE_NUMBER_TYPES = %w(
+      LATEST
+      TRIM_HORIZON
+    )
+
+    SHARD_ITERATOR_TYPES =
+      STARTING_SEQUENCE_NUMBER_TYPES +
+      NO_STARTING_SEQUENCE_NUMBER_TYPES
+
+    Fluent::Plugin.register_input('kinesis',self)
+
+    config_param :aws_key_id,  :string, default: nil
+    config_param :aws_sec_key, :string, default: nil
+    config_param :region,      :string, default: nil
+
+    config_param :profile,          :string, :default => nil
+    config_param :credentials_path, :string, :default => nil
+
+    config_param :stream_name,         :string
+    config_param :shards,              :hash,   default: nil
+    config_param :shard_iterator_type, :string, default: 'LATEST'
+
+    config_param :tag,      :string
+    config_param :interval, :integer, default: 1
+    config_param :db,       :string,  default: nil
+
+    config_param :json_data, :bool, default: false
+
+    config_param :debug, :bool, default: false
+
+    def configure(conf)
+      super
+      @shard_iterator_type.upcase!
+
+      unless SHARD_ITERATOR_TYPES.include?(@shard_iterator_type)
+        raise Fluent::ConfigError, "'shard_iterator_type' must be one of the following values: #{SHARD_ITERATOR_TYPES.join(',')}"
+      end
+    end
+
+    def start
+      super
+      load_client
+
+      @db = GDBM.open(@db) if @db
+      @loop = Coolio::Loop.new
+
+      shard_iterators.map do |shard_id, shard_iterator|
+        timer = TimerWatcher.new(@interval, true, log) do
+          shard_iterator = fetch(shard_id, shard_iterator)
+        end
+
+        @loop.attach(timer)
+      end
+
+      @thread = Thread.new(&method(:run))
+    end
+
+    def shutdown
+      @loop.stop
+      @thread.join
+      @db.close if @db
+    end
+
+    private
+
+    def run
+      @loop.run
+    rescue => e
+      @log.error(e.message)
+      @log.error_backtrace(e.backtrace)
+    end
+
+    def fetch(shard_id, shard_iterator)
+      resp = @client.get_records(shard_iterator: shard_iterator)
+      seq_num = nil
+
+      resp.each do |page|
+        records = page[:records]
+        seq_num = records.last[:sequence_number] if records.last
+        emit_records(shard_id, records)
+        shard_iterator = page[:next_shard_iterator]
+      end
+
+      if @db and seq_num
+        @db[shard_id] = seq_num
+      end
+
+      shard_iterator
+    end
+
+    def emit_records(shard_id, records)
+      time = Time.now.to_i
+
+      records.each do |record|
+        record = record.to_h
+        record[:shard_id] = shard_id
+
+        if @json_data
+          begin
+            json = JSON.parse(record[:data])
+            record.update(json)
+            record.delete(:data)
+          rescue JSON::ParserError => e
+            @log.warn(e.message)
+            @log.warn_backtrace(e.backtrace)
+          end
+        end
+
+        tag = @tag.gsub(/\${([^}]+)}/) { record[$1] }
+        Fluent::Engine.emit(tag, time, record)
+      end
+    end
+
+    def shard_iterators
+      @shards = get_shards unless @shards
+      @shards.update(shards_from_store)
+
+      @shards.map do |shard_id, starting_sequence_number|
+        params = {
+          stream_name: @stream_name,
+          shard_id: shard_id,
+          shard_iterator_type: @shard_iterator_type.upcase,
+        }
+
+        if STARTING_SEQUENCE_NUMBER_TYPES.include?(@shard_iterator_type)
+          params[:starting_sequence_number] = starting_sequence_number
+        end
+
+        resp = @client.get_shard_iterator(params)
+
+        [shard_id, resp[:shard_iterator]]
+      end
+    end
+
+    def shards_from_store
+      shards = {}
+
+      if @db
+        @db.each do |shard_id, sequence_number|
+          shards[shard_id] = sequence_number
+        end
+      end
+
+      shards
+    end
+
+    def get_shards
+      seq_num_by_shard_id = {}
+      resp = @client.describe_stream(stream_name: @stream_name)
+
+      resp.each do |page|
+        page.stream_description.shards.each do |shard|
+          shard_id = shard.shard_id
+          seq_num = shard.sequence_number_range.starting_sequence_number
+          seq_num_by_shard_id[shard_id] = seq_num
+        end
+      end
+
+      seq_num_by_shard_id
+    end
+
+    def load_client
+
+      user_agent_suffix = "#{USER_AGENT_NAME}/#{FluentPluginKinesis::VERSION}"
+
+      options = {
+        user_agent_suffix: user_agent_suffix
+      }
+
+      if @region
+        options[:region] = @region
+      end
+
+      if @aws_key_id && @aws_sec_key
+        options.update(
+          access_key_id: @aws_key_id,
+          secret_access_key: @aws_sec_key,
+        )
+      elsif @profile
+        credentials_opts = {:profile_name => @profile}
+        credentials_opts[:path] = @credentials_path if @credentials_path
+        credentials = Aws::SharedCredentials.new(credentials_opts)
+        options[:credentials] = credentials
+      end
+
+      if @debug
+        options.update(
+          logger: Logger.new(log.out),
+          log_level: :debug,
+        )
+        # XXX: Add the following options, if necessary
+        # :http_wire_trace => true
+      end
+
+      @client = Aws::Kinesis::Client.new(options)
+
+    end
+
+    class TimerWatcher < Coolio::TimerWatcher
+      def initialize(interval, repeat, log, &callback)
+        @callback = callback
+        @log = log
+        super(interval, repeat)
+      end
+
+      def on_timer
+        @callback.call
+      rescue => e
+        @log.error(e.message)
+        @log.error_backtrace(e.backtrace)
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,6 +14,7 @@
 require 'rubygems'
 require 'bundler'
 require 'stringio'
+require 'ostruct'
 begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
@@ -24,8 +25,10 @@ end
 
 require 'test/unit'
 require 'test/unit/rr'
+require 'timecop'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
 require 'fluent/plugin/out_kinesis'
+require 'fluent/plugin/in_kinesis'

--- a/test/plugin/test_in_kinesis.rb
+++ b/test/plugin/test_in_kinesis.rb
@@ -1,0 +1,325 @@
+require 'helper'
+
+class KinesisInputcTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    aws_key_id test_key_id
+    aws_sec_key test_sec_key
+    region us-east-1
+    stream_name test_stream
+    tag test
+  ]
+
+  def create_driver(conf = CONFIG)
+    Fluent::Test::InputTestDriver
+      .new(FluentPluginKinesis::Input).configure(conf)
+  end
+
+  def create_mock_clinet
+    client = mock(Object.new)
+    mock(Aws::Kinesis::Client).new({}) { client }
+    return client
+  end
+
+  def to_stub(obj)
+    case obj
+    when Array
+      obj.map {|v| to_stub(v) }
+    when Hash
+      OpenStruct.new(Hash[*obj.map {|k, v| [k, to_stub(v)] }.flatten(1)])
+    else
+      obj
+    end
+  end
+
+  def test_configure
+    d = create_driver(<<-EOS)
+      #{CONFIG}
+      interval 3
+    EOS
+
+    assert_equal 'test_key_id', d.instance.aws_key_id
+    assert_equal 'test_sec_key', d.instance.aws_sec_key
+    assert_equal 'us-east-1', d.instance.region
+    assert_equal 'test_stream', d.instance.stream_name
+    assert_equal 'test', d.instance.tag
+    assert_equal 3, d.instance.interval
+  end
+
+  def test_configure_with_credentials
+    d = create_driver(<<-EOS)
+      profile default
+      credentials_path /home/scott/.aws/credentials
+      stream_name test_stream
+      region us-east-1
+      tag test
+    EOS
+
+    assert_equal 'default', d.instance.profile
+    assert_equal '/home/scott/.aws/credentials', d.instance.credentials_path
+    assert_equal 'test_stream', d.instance.stream_name
+    assert_equal 'us-east-1', d.instance.region
+    assert_equal 'test', d.instance.tag
+  end
+
+  def test_load_client
+    client = stub(Object.new)
+    client.describe_stream {
+      to_stub([
+        { stream_description: {
+            shards: [
+              {
+                shard_id: 'shardId-000000000000',
+                sequence_number_range: {
+                  starting_sequence_number: '12345678901234567890123456789012345678901234567890123456'}}]}}])
+    }
+
+    client.get_shard_iterator { {shard_iterator: 'SHARD_ITERATOR'} }
+
+    client.get_records {
+      [{
+        records: [],
+        next_shard_iterator: 'NEXT_SHARD_ITERATOR'
+      }]
+    }
+
+    stub(Aws::Kinesis::Client).new do |options|
+      assert_equal("test_key_id", options[:access_key_id])
+      assert_equal("test_sec_key", options[:secret_access_key])
+      assert_equal("us-east-1", options[:region])
+      client
+    end
+
+    d = create_driver
+    d.run
+  end
+
+  def test_load_client_with_credentials
+    client = stub(Object.new)
+    client.describe_stream {
+      to_stub([
+        { stream_description: {
+            shards: [
+              {
+                shard_id: 'shardId-000000000000',
+                sequence_number_range: {
+                  starting_sequence_number: '12345678901234567890123456789012345678901234567890123456'}}]}}])
+    }
+
+    client.get_shard_iterator { {shard_iterator: 'SHARD_ITERATOR'} }
+
+    client.get_records {
+      [{
+        records: [],
+        next_shard_iterator: 'NEXT_SHARD_ITERATOR'
+      }]
+    }
+
+    stub(Aws::Kinesis::Client).new do |options|
+      assert_equal(nil, options[:access_key_id])
+      assert_equal(nil, options[:secret_access_key])
+      assert_equal("us-east-1", options[:region])
+
+      credentials = options[:credentials]
+      assert_equal("default", credentials.profile_name)
+      assert_equal("/home/scott/.aws/credentials", credentials.path)
+
+      client
+    end
+
+    d = create_driver(<<-EOS)
+      profile default
+      credentials_path /home/scott/.aws/credentials
+      stream_name test_stream
+      region us-east-1
+      tag test
+    EOS
+
+    d.run
+  end
+
+  def test_configure_with_shard_iterator_type
+    d = create_driver(<<-EOS)
+      #{CONFIG}
+      shard_iterator_type AT_SEQUENCE_NUMBER
+      shards {"shardId-000000000000":"12345678901234567890123456789012345678901234567890123456"}
+    EOS
+
+    assert_equal 'test_key_id', d.instance.aws_key_id
+    assert_equal 'test_sec_key', d.instance.aws_sec_key
+    assert_equal 'us-east-1', d.instance.region
+    assert_equal 'test_stream', d.instance.stream_name
+    assert_equal 'test', d.instance.tag
+    assert_equal 'AT_SEQUENCE_NUMBER', d.instance.shard_iterator_type
+    assert_equal({"shardId-000000000000" => "12345678901234567890123456789012345678901234567890123456"}, d.instance.shards)
+  end
+
+  def test_configure_with_invalid_shard_iterator_type
+    assert_raise(Fluent::ConfigError) {
+      create_driver(<<-EOS)
+        #{CONFIG}
+        shard_iterator_type xLATEST
+      EOS
+    }
+  end
+
+  def test_configure_with_shards
+    d = create_driver(<<-EOS)
+      #{CONFIG}
+      shards {"shardId-000000000000":"12345678901234567890123456789012345678901234567890123456"}
+      shard_iterator_type AT_SEQUENCE_NUMBER
+    EOS
+
+    assert_equal 'test_key_id', d.instance.aws_key_id
+    assert_equal 'test_sec_key', d.instance.aws_sec_key
+    assert_equal 'us-east-1', d.instance.region
+    assert_equal 'test_stream', d.instance.stream_name
+    assert_equal 'test', d.instance.tag
+    assert_equal 'AT_SEQUENCE_NUMBER', d.instance.shard_iterator_type
+    assert_equal({"shardId-000000000000"=>"12345678901234567890123456789012345678901234567890123456"}, d.instance.shards)
+  end
+
+  def test_fetch
+    d = create_driver(<<-EOS)
+      #{CONFIG}
+      shard_iterator_type AT_SEQUENCE_NUMBER
+    EOS
+
+    client = create_mock_clinet
+
+    client.describe_stream(stream_name: 'test_stream') {
+      to_stub([
+        { stream_description: {
+            shards: [
+              {
+                shard_id: 'shardId-000000000000',
+                sequence_number_range: {
+                  starting_sequence_number: '12345678901234567890123456789012345678901234567890123456'}}]}}])
+    }
+
+    client.get_shard_iterator(
+      stream_name: 'test_stream',
+      shard_id: 'shardId-000000000000',
+      shard_iterator_type: 'AT_SEQUENCE_NUMBER',
+      starting_sequence_number: '12345678901234567890123456789012345678901234567890123456',
+    ) { {shard_iterator: 'SHARD_ITERATOR'} }
+
+    client.get_records(shard_iterator: 'SHARD_ITERATOR') {
+      [{
+        records: [
+          {data: 'data1', sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+          {data: 'data2', sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+        ],
+        next_shard_iterator: 'NEXT_SHARD_ITERATOR'
+      }]
+    }
+
+    Timecop.freeze(Time.parse('2011-01-02T13:14:15Z')) do
+      d.run
+    end
+
+    assert_equal d.emits, [
+      ["test", 1293974055, {data: "data1", sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+      ["test", 1293974055, {data: "data2", sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+    ]
+  end
+
+  def test_fetch_json
+    d = create_driver(<<-EOS)
+      #{CONFIG}
+      shard_iterator_type AT_SEQUENCE_NUMBER
+      json_data true
+    EOS
+
+    client = create_mock_clinet
+
+    client.describe_stream(stream_name: 'test_stream') {
+      to_stub([
+        { stream_description: {
+            shards: [
+              {
+                shard_id: 'shardId-000000000000',
+                sequence_number_range: {
+                  starting_sequence_number: '12345678901234567890123456789012345678901234567890123456'}}]}}])
+    }
+
+    client.get_shard_iterator(
+      stream_name: 'test_stream',
+      shard_id: 'shardId-000000000000',
+      shard_iterator_type: 'AT_SEQUENCE_NUMBER',
+      starting_sequence_number: '12345678901234567890123456789012345678901234567890123456',
+    ) { {shard_iterator: 'SHARD_ITERATOR'} }
+
+    client.get_records(shard_iterator: 'SHARD_ITERATOR') {
+      [{
+        records: [
+          {data: JSON.dump(data1_key1: 'val1', data1_key2: 'val2'), sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+          {data: JSON.dump(data2_key1: 'val1', data2_key2: 'val2'), sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+        ],
+        next_shard_iterator: 'NEXT_SHARD_ITERATOR'
+      }]
+    }
+
+    Timecop.freeze(Time.parse('2011-01-02T13:14:15Z')) do
+      d.run
+    end
+
+    assert_equal d.emits, [
+      ["test", 1293974055, {"data1_key1" => 'val1', "data1_key2" => 'val2', sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+      ["test", 1293974055, {"data2_key1" => 'val1', "data2_key2" => 'val2', sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+    ]
+  end
+
+  def test_tag_placeholder
+    d = create_driver(<<-EOS)
+      aws_key_id test_key_id
+      aws_sec_key test_sec_key
+      region us-east-1
+      stream_name test_stream
+      tag test.${foo}.${bar}
+      shard_iterator_type AT_SEQUENCE_NUMBER
+      json_data true
+    EOS
+
+    client = create_mock_clinet
+
+    client.describe_stream(stream_name: 'test_stream') {
+      to_stub([
+        { stream_description: {
+            shards: [
+              {
+                shard_id: 'shardId-000000000000',
+                sequence_number_range: {
+                  starting_sequence_number: '12345678901234567890123456789012345678901234567890123456'}}]}}])
+    }
+
+    client.get_shard_iterator(
+      stream_name: 'test_stream',
+      shard_id: 'shardId-000000000000',
+      shard_iterator_type: 'AT_SEQUENCE_NUMBER',
+      starting_sequence_number: '12345678901234567890123456789012345678901234567890123456',
+    ) { {shard_iterator: 'SHARD_ITERATOR'} }
+
+    client.get_records(shard_iterator: 'SHARD_ITERATOR') {
+      [{
+        records: [
+          {data: JSON.dump(foo: 'FOO1', bar: 'BAR1'), sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+          {data: JSON.dump(foo: 'FOO2', bar: 'BAR2'), sequence_number: 'SEQUENCE_NUMBER', partition_key: 'PARTITION_KEY'},
+        ],
+        next_shard_iterator: 'NEXT_SHARD_ITERATOR'
+      }]
+    }
+
+    Timecop.freeze(Time.parse('2011-01-02T13:14:15Z')) do
+      d.run
+    end
+
+    assert_equal d.emits, [
+      ["test.FOO1.BAR1", 1293974055, {"foo" => 'FOO1', "bar" => 'BAR1', sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+      ["test.FOO2.BAR2", 1293974055, {"foo" => 'FOO2', "bar" => 'BAR2', sequence_number: "SEQUENCE_NUMBER", partition_key: "PARTITION_KEY", shard_id: "shardId-000000000000"}],
+    ]
+  end
+end


### PR DESCRIPTION
I've implemented the input plug-in.
Please add it if there is no problem. :bow:

Exapmle configuration:
```
<source>
  type kinesis
  stream_name my-stream
  tag kinesis.data
  shard_iterator_type AFTER_SEQUENCE_NUMBER
  shards {"shardId-000000000000":"49545736698179024714137668171499632182578095385061883906"}
  db /var/tmp/kinesis.db
  #json_data true
</source>
```

---
Parse "data" attr as JSON if `json_data` is `true`:
```
put_record(data: '{"key1": "val1", "key2": "val2"}'
-> get_record:
{ ... "key1": "val1", "key2": "val2", ...}
```
see https://github.com/winebarrel/aws-fluent-plugin-kinesis/blob/7de7972ec569e22c7c59b4a3ba1ced55f21f37a1/test/plugin/test_in_kinesis.rb#L178

---
Use placeholder if `tag` is `kinesis.${foo}`

```
<source>
  tag kinesis.${foo}
  ...
</source>
```

```
put_record(data: '{"foo": "bar"}'
-> emit recoed tag: kinesis.bar 
```