### PR TITLE
Removing second base64 encoding

### DIFF
--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -1,5 +1,4 @@
 require 'aws-sdk-core'
-require 'base64'
 require 'multi_json'
 require 'logger'
 require 'securerandom'
@@ -83,7 +82,7 @@ module FluentPluginKinesis
       # http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html
       data = {
         stream_name: @stream_name,
-        data: Base64.strict_encode64(record.to_json),
+        data: record.to_json,
         partition_key: get_key(:partition_key,record)
       }
 

--- a/test/plugin/test_out_kinesis.rb
+++ b/test/plugin/test_out_kinesis.rb
@@ -139,12 +139,12 @@ class KinesisOutputTest < Test::Unit::TestCase
 
     d.expect_format({
       'stream_name' => 'test_stream',
-      'data' => Base64.strict_encode64(data1.to_json),
+      'data' => data1.to_json,
       'partition_key' => 'key1' }.to_msgpack
     )
     d.expect_format({
       'stream_name' => 'test_stream',
-      'data' => Base64.strict_encode64(data2.to_json),
+      'data' => data2.to_json,
       'partition_key' => 'key2' }.to_msgpack
     )
 
@@ -152,12 +152,12 @@ class KinesisOutputTest < Test::Unit::TestCase
     client.describe_stream(stream_name: 'test_stream')
     client.put_record(
       stream_name: 'test_stream',
-      data: Base64.strict_encode64(data1.to_json),
+      data: data1.to_json,
       partition_key: 'key1'
     )
     client.put_record(
       stream_name: 'test_stream',
-      data: Base64.strict_encode64(data2.to_json),
+      data: data2.to_json,
       partition_key: 'key2'
     )
 
@@ -170,7 +170,7 @@ class KinesisOutputTest < Test::Unit::TestCase
     assert_equal(
         MessagePack.pack({
             "stream_name"       => "test_stream",
-            "data"              => Base64.strict_encode64(data.to_json),
+            "data"              => data.to_json,
             "partition_key"     => "key1"
         }),
         d.instance.format('test','test',data)
@@ -194,7 +194,7 @@ class KinesisOutputTest < Test::Unit::TestCase
     assert_equal(
         MessagePack.pack({
             "stream_name"       => "test_stream",
-            "data"              => Base64.strict_encode64(data.to_json),
+            "data"              => data.to_json,
             "partition_key"     => "key1",
             "explicit_hash_key" => "hash1"
         }),


### PR DESCRIPTION
As per AWS documentation (http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax) : "The data blob to put into the record, which is base64-encoded when the blob is serialized. The maximum size of the data blob (the payload before base64-encoding) is 50 kilobytes (KB)". Encoding before we send the data blob produces doubly encoded data strings.
