### PR TITLE
Expand aws-sdk-core version dependency

### DIFF
--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
 
   spec.add_dependency "fluentd", ">= 0.10.53", "< 0.13"
-  spec.add_dependency "aws-sdk-core", ">= 2.0.12 and < 3.0"
+  spec.add_dependency "aws-sdk-core", ">= 2.0.12", "< 3.0"
   spec.add_dependency "multi_json", "~> 1.0"
   spec.add_dependency "msgpack", ">= 0.5.8"
 end

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
 
   spec.add_dependency "fluentd", ">= 0.10.53", "< 0.13"
-  spec.add_dependency "aws-sdk-core", "~> 2.0"
+  spec.add_dependency "aws-sdk-core", ">= 2.0.12 and < 3.0"
   spec.add_dependency "multi_json", "~> 1.0"
   spec.add_dependency "msgpack", ">= 0.5.8"
 end

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit-rr", "~> 1.0"
 
   spec.add_dependency "fluentd", ">= 0.10.53", "< 0.13"
-  spec.add_dependency "aws-sdk-core", "~> 2.0.12"
+  spec.add_dependency "aws-sdk-core", "~> 2.0"
   spec.add_dependency "multi_json", "~> 1.0"
   spec.add_dependency "msgpack", ">= 0.5.8"
 end


### PR DESCRIPTION
By changing the version to `~>2.0` then users can safely upgrade to `2.1`, `2.2`, etc. The `aws-sdk-core` gem follows semver, so minor version bumps should be backwards compatible.