### PR TITLE
Mark access keys as secret

### DIFF
--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -35,8 +35,8 @@ module FluentPluginKinesis
     config_set_default :include_time_key, true
     config_set_default :include_tag_key,  true
 
-    config_param :aws_key_id,  :string, default: nil
-    config_param :aws_sec_key, :string, default: nil
+    config_param :aws_key_id,  :string, default: nil, :secret => true
+    config_param :aws_sec_key, :string, default: nil, :secret => true
     # The 'region' parameter is optional because
     # it may be set as an environment variable.
     config_param :region,      :string, default: nil


### PR DESCRIPTION
So they will not get printed out by fluentd

This is done in the s3 plugin as well: https://github.com/fluent/fluent-plugin-s3/commit/a678d899fab871e97a86e9b621ef2d1a523ef17b