### PR TITLE
add truncate for too long "size_exceeded_log_message"

### DIFF
--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -31,6 +31,7 @@ module FluentPluginKinesis
     PUT_RECORDS_MAX_COUNT = 500
     PUT_RECORD_MAX_DATA_SIZE = 1024 * 1024
     PUT_RECORDS_MAX_DATA_SIZE = 1024 * 1024 * 5
+    ERROR_MESSAGE_MAX_DATA_SIZE = PUT_RECORD_MAX_DATA_SIZE - 100
 
     Fluent::Plugin.register_output('kinesis',self)
 
@@ -316,10 +317,10 @@ module FluentPluginKinesis
     def build_sizeexceeded_error_message(record)
       notification = '...(message truncated.)'
       message = sprintf('Record exceeds the %.3f KB(s) per-record size limit and will not be delivered: %s', PUT_RECORD_MAX_DATA_SIZE / 1024.0, record)
-      if(message.length <= PUT_RECORD_MAX_DATA_SIZE)
+      if(message.length <= ERROR_MESSAGE_MAX_DATA_SIZE)
         message
       else
-        truncated_message = message.slice(0,PUT_RECORD_MAX_DATA_SIZE - notification.length) + notification
+        truncated_message = message.slice(0,ERROR_MESSAGE_MAX_DATA_SIZE - notification.length) + notification
         truncated_message
       end
     end

--- a/lib/fluent/plugin/out_kinesis.rb
+++ b/lib/fluent/plugin/out_kinesis.rb
@@ -131,7 +131,7 @@ module FluentPluginKinesis
         unless record_exceeds_max_size?(record[:data])
           true
         else
-          log.error sprintf('Record exceeds the %.3f KB(s) per-record size limit and will not be delivered: %s', PUT_RECORD_MAX_DATA_SIZE / 1024.0, record[:data])
+          log.error build_sizeexceeded_error_message(record[:data])
           false
         end
       }
@@ -311,6 +311,17 @@ module FluentPluginKinesis
 
     def record_exceeds_max_size?(record_string)
       return record_string.length > PUT_RECORD_MAX_DATA_SIZE
+    end
+
+    def build_sizeexceeded_error_message(record)
+      notification = '...(message truncated.)'
+      message = sprintf('Record exceeds the %.3f KB(s) per-record size limit and will not be delivered: %s', PUT_RECORD_MAX_DATA_SIZE / 1024.0, record)
+      if(message.length <= PUT_RECORD_MAX_DATA_SIZE)
+        message
+      else
+        truncated_message = message.slice(0,PUT_RECORD_MAX_DATA_SIZE - notification.length) + notification
+        truncated_message
+      end
     end
   end
 end

--- a/test/plugin/test_out_kinesis.rb
+++ b/test/plugin/test_out_kinesis.rb
@@ -641,22 +641,22 @@ class KinesisOutputTest < Test::Unit::TestCase
 
   def test_build_sizeexceeded_error_message
     d = create_driver
-    original_put_record_max_data_size = d.instance.class.send(:remove_const, :PUT_RECORD_MAX_DATA_SIZE) if d.instance.class.const_defined?(:PUT_RECORD_MAX_DATA_SIZE)
-    tmp_put_record_max_data_size = 100
-    d.instance.class.const_set(:PUT_RECORD_MAX_DATA_SIZE, tmp_put_record_max_data_size)
+    original_error_message_max_data_size = d.instance.class.send(:remove_const, :ERROR_MESSAGE_MAX_DATA_SIZE) if d.instance.class.const_defined?(:PUT_RECORD_MAX_DATA_SIZE)
+    tmp_error_message_max_data_size = 100
+    d.instance.class.const_set(:ERROR_MESSAGE_MAX_DATA_SIZE, tmp_error_message_max_data_size)
 
     assert_operator(
-      tmp_put_record_max_data_size, :>=,
+      tmp_error_message_max_data_size, :>=,
       d.instance.send(:build_sizeexceeded_error_message,'test').length
     )
 
     assert_operator(
-      tmp_put_record_max_data_size, :==,
+      tmp_error_message_max_data_size, :==,
       d.instance.send(:build_sizeexceeded_error_message,(0...1024).map{|i|'a'}.join('')).length
     )
 
     assert_operator(
-      tmp_put_record_max_data_size, :==,
+      tmp_error_message_max_data_size, :==,
       d.instance.send(:build_sizeexceeded_error_message,(0...99).map{|i|'a'}.join('')).length
     )
   end

--- a/test/plugin/test_out_kinesis.rb
+++ b/test/plugin/test_out_kinesis.rb
@@ -638,4 +638,26 @@ class KinesisOutputTest < Test::Unit::TestCase
         d.instance.send(:calculate_sleep_duration,2)
     )
   end
+
+  def test_build_sizeexceeded_error_message
+    d = create_driver
+    original_put_record_max_data_size = d.instance.class.send(:remove_const, :PUT_RECORD_MAX_DATA_SIZE) if d.instance.class.const_defined?(:PUT_RECORD_MAX_DATA_SIZE)
+    tmp_put_record_max_data_size = 100
+    d.instance.class.const_set(:PUT_RECORD_MAX_DATA_SIZE, tmp_put_record_max_data_size)
+
+    assert_operator(
+      tmp_put_record_max_data_size, :>=,
+      d.instance.send(:build_sizeexceeded_error_message,'test').length
+    )
+
+    assert_operator(
+      tmp_put_record_max_data_size, :==,
+      d.instance.send(:build_sizeexceeded_error_message,(0...1024).map{|i|'a'}.join('')).length
+    )
+
+    assert_operator(
+      tmp_put_record_max_data_size, :==,
+      d.instance.send(:build_sizeexceeded_error_message,(0...99).map{|i|'a'}.join('')).length
+    )
+  end
 end


### PR DESCRIPTION
According to https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/32, I added truncation in log emitting for 'size_exceeded_error' because it currently emits whole which causes the error. In some cases like collecting those logs and emitting also Kinesis, it causes recursively same error.

The changes are provided under Apache License 2.0.

Thanks!