### PR TITLE
Support deriving stream name from tag

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/class_methods.rb
+++ b/lib/fluent/plugin/kinesis_helper/class_methods.rb
@@ -45,9 +45,10 @@ module Fluent
 
       def config_param_for_producer
         const_set(:RequestType, :producer)
-        config_param :stream_name,   :string
-        config_param :region,        :string, default: nil
-        config_param :partition_key, :string, default: nil
+        config_param :stream_name,        :string, default: nil
+        config_param :stream_name_prefix, :string, default: nil
+        config_param :region,             :string, default: nil
+        config_param :partition_key,      :string, default: nil
         config_param_for_credentials
         config_param_for_format
         config_param_for_debug

--- a/lib/fluent/plugin/out_kinesis_producer.rb
+++ b/lib/fluent/plugin/out_kinesis_producer.rb
@@ -20,6 +20,16 @@ module Fluent
     Fluent::Plugin.register_output('kinesis_producer', self)
     config_param_for_producer
 
+    def configure(conf)
+      super
+      unless @stream_name or @stream_name_prefix
+        raise Fluent::ConfigError, "'stream_name' or 'stream_name_prefix' is required"
+      end
+      if @stream_name and @stream_name_prefix
+        raise Fluent::ConfigError, "Only one of 'stream_name' or 'stream_name_prefix' is allowed"
+      end
+    end
+
     def write(chunk)
       records = convert_to_records(chunk)
       wait_futures(write_chunk_to_kpl(records))
@@ -31,7 +41,7 @@ module Fluent
       {
         data: data_format(tag, time, record),
         partition_key: key(record),
-        stream_name: @stream_name,
+        stream_name: @stream_name ? @stream_name : @stream_name_prefix + tag,
       }
     end
   end


### PR DESCRIPTION
Add support for kinesis_producer to derive the stream name by concatenating stream_name_prefix (new configuration option) and the fluentd tag. Fixes #67.