### PR TITLE
Set default "BatchRequestLimitSize" for kinesis_streams to 5MB - 1B

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Boolean, default `true`. If enabled, when after retrying, the next retrying chec
 Integer, default 500. The number of max count of making batch request from record chunk. It can't exceed the default value because it's API limit.
 
 ### batch_request_max_size
-Integer, default 5 * 1024*1024. The number of max size of making batch request from record chunk. It can't exceed the default value because it's API limit.
+Integer, default (5 * 1024*1024) - 1. The number of max size of making batch request from record chunk. It can't exceed the default value because it's API limit.
 
 ### http_proxy
 HTTP proxy for API calling. Default `nil`.

--- a/lib/fluent/plugin/kinesis_helper/class_methods.rb
+++ b/lib/fluent/plugin/kinesis_helper/class_methods.rb
@@ -18,7 +18,7 @@ module Fluent
       def config_param_for_streams
         const_set(:RequestType, :streams)
         const_set(:BatchRequestLimitCount, 500)
-        const_set(:BatchRequestLimitSize, 5 * 1024 * 1024)
+        const_set(:BatchRequestLimitSize, ((5 * 1024 * 1024) - 1))
         config_param :stream_name,   :string
         config_param :region,        :string,  default: nil
         config_param :partition_key, :string,  default: nil


### PR DESCRIPTION
We are using fluent-plugin-kinesis on thousands of hosts in our fleet (thank you!), and have seen this issue on 2 hosts in the past week:

```
2016-08-04 04:31:26 -0700 [warn]: fluent/output.rb:371:rescue in try_flush: temporarily failed to flush the buffer. next_retry=2016-08-04 04:36:26 -0700 error_class="Aws::Kinesis::Errors::InvalidArgumentException" error="Records size exceeds 5 MB limit" plugin_id="kinesis-out"
2016-08-04 04:36:26 -0700 [warn]: fluent/output.rb:371:rescue in try_flush: temporarily failed to flush the buffer. next_retry=2016-08-04 04:41:26 -0700 error_class="Aws::Kinesis::Errors::InvalidArgumentException" error="Records size exceeds 5 MB limit" plugin_id="kinesis-out"
... <continues forever> ...
```

... which leaves the host unable to send logs to kinesis and the fluentd local file output buffer fills up.

On a hunch, I figured out that there was an off-by-one error in the max-size logic, and was able to fix on our host by reducing `batch_request_max_size` to the default value, minus 1 byte:
```
# Set limit to: 5MB - 1 byte
batch_request_max_size    5242879  
```

After fluentd restart, writing to Kinesis is able to proceed:
```
2016-08-04 09:12:29 -0700 [debug]: plugin/out_kinesis_streams.rb:28:write: Written 7032 records
2016-08-04 09:12:33 -0700 [debug]: plugin/out_kinesis_streams.rb:28:write: Written 8789 records
2016-08-04 09:12:38 -0700 [debug]: plugin/out_kinesis_streams.rb:28:write: Written 11541 records
2016-08-04 09:12:43 -0700 [debug]: plugin/out_kinesis_streams.rb:28:write: Written 11329 records
2016-08-04 09:12:48 -0700 [debug]: plugin/out_kinesis_streams.rb:28:write: Written 12050 records
```

### Notes:

* Alternatively one might want to fix this here: https://github.com/awslabs/aws-fluent-plugin-kinesis/blob/master/lib/fluent/plugin/kinesis_helper/api.rb#L61
* Looks like `kinesis_firehose` has a 4MB limit. That may need to be dropped by 1 byte too. I don't know since I don't use Firehose.