### PR TITLE
Adjust credentials_provider for newer version of aws-ruby-sdk

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/credentials.rb
+++ b/lib/fluent/plugin/kinesis_helper/credentials.rb
@@ -38,7 +38,7 @@ module Fluent
       private
 
       def default_credentials_provider
-        config_class = Struct.new(:access_key_id, :secret_access_key, :region, :session_token, :profile)
+        config_class = Struct.new(:access_key_id, :secret_access_key, :region, :session_token, :profile, :instance_profile_credentials_retries, :instance_profile_credentials_timeout)
         config = config_class.new(@aws_key_id, @aws_sec_key, @region)
         provider = Aws::CredentialProviderChain.new(config).resolve
         if provider.nil?


### PR DESCRIPTION
Fix #93 .

See also https://github.com/aws/aws-sdk-ruby/commit/469c66ada098d043e85bb291b07f424516bf24d7