### PR TITLE
Don't create too-long records from too-long records (leading to outage).

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/error.rb
+++ b/lib/fluent/plugin/kinesis_helper/error.rb
@@ -25,7 +25,7 @@ module Fluent
 
     class ExceedMaxRecordSizeError < SkipRecordError
       def initialize(record)
-        super "Record size limit exceeded for #{record}"
+        super "Record size limit exceeded for #{record.length}-byte record: #{record.splice(0,1024)}...#{record.splice(-1024,1024)}"
       end
     end
 


### PR DESCRIPTION
Without this patch, a single too-long record causes an even longer record
to be logged (which can cause the same error which logs an even longer
record, eventually leading to a progression of insanely long records consuming
available capacity and effectively halting nearly all other transfers).