### PR TITLE
Skip empty batches

### DIFF
--- a/lib/fluent/plugin/out_kinesis_streams.rb
+++ b/lib/fluent/plugin/out_kinesis_streams.rb
@@ -23,6 +23,7 @@ module Fluent
     def write(chunk)
       records = convert_to_records(chunk)
       split_to_batches(records).each do |batch|
+        next unless batch.size > 0
         batch_request_with_retry(batch)
       end
       log.debug("Written #{records.size} records")

--- a/test/plugin/test_out_kinesis_streams.rb
+++ b/test/plugin/test_out_kinesis_streams.rb
@@ -97,6 +97,15 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
     assert_equal 1, d.instance.log.logs.size
   end
 
+  def test_single_max_record_size
+    d = create_driver
+    d.emit({"a"=>"a"*(1024*1024-'{"a":""}'.size+1)}) # exceeded
+    d.run
+    assert_equal 0, @server.records.size
+    assert_equal 0, @server.error_count
+    assert_equal 1, d.instance.log.logs.size
+  end
+
   pad = 32 + '{"data":""}'.size
   data(
     'split_by_count'           => [Array.new(501, {data:'a'}),                                        [500,1]],


### PR DESCRIPTION
A ValidationException is thrown by Kinesis when fluentd receives log messages that are all more than 1MB in size. The reason is that all messages will be skipped and an empty batch is send to Kinesis which will throw the validation exception. This will cause the batch to fail and all messages will stay in the buffer causing it to fill up. This patch will skip any empty batches.