### PR TITLE
[FIX] require aws-sdk-core before requiring the aws related libraries

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 
 require 'fluent/configurable'
+require 'aws-sdk-core'
 
 module Fluent
   module KinesisHelper

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require 'aws-sdk-core'
 require 'fluent/test'
 require 'fluent/test/helpers'
 def fluentd_v0_12?


### PR DESCRIPTION
introduced at https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/131/files

# Why

`aws-sdk-core` library should be installed in the first place to get the version by `Gem.loaded_specs['aws-sdk-core']`.

However in the following logic, **`aws-sdk-core` is not required and `Gem.loaded_specs['aws-sdk-core']` returns nil**. Then `NoMethoError` would be thrown.

```ruby
      def aws_sdk_v2?
        # Gem.loaded_specs['aws-sdk-core'] #=> nil
        @aws_sdk_v2 ||= Gem.loaded_specs['aws-sdk-core'].version < Gem::Version.create('3')
      end
      ...
          if aws_sdk_v2?
            # these library require "aws-sdk-core" as a dependency library
            # Therefore, before requiring "aws-sdk" or "aws-sdk-kinesis", 
            # Gem.loaded_specs['aws-sdk-core'] returns nil
            require 'aws-sdk'
          else
            require 'aws-sdk-kinesis'
          end
```

# Solution

I simply put `require 'aws-sdk-core'` in the first line of the `client.rb`. How do you think about this?

# How to reproduce

simply run `ruby test/helper.rb` on the local environmnet.

```ruby
 aws-fluent-plugin-kinesis (master)  ∫  ruby test/helper.rb
Traceback (most recent call last):
	1: from test/helper.rb:39:in `<main>'
test/helper.rb:21:in `aws_sdk_v2?': undefined method `version' for nil:NilClass (NoMethodError)
```