### PR TITLE
Use sdk v3 now that fluent-plugin-s3 also uses it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: ruby
+os: linux
+sudo: false
 
 matrix:
   include:
     - rvm: 2.4.1
-      os: linux
       gemfile: Gemfile
-    - rvm: 2.1.10
-      os: linux
-      gemfile: gemfiles/Gemfile.td-agent-2.3.5
+    - rvm: 2.4.4 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L22
+      gemfile: gemfiles/Gemfile.td-agent-3.2.0
 
 script: bundle exec rake test
-
-sudo: false

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -31,15 +31,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency "fluentd", ">= 0.12.35", "< 2"
-  spec.add_dependency "aws-sdk", ">= 2.9.9", "< 4"
-  # TODO: fluent-plugin-s3 depends on v2 only.
-  # https://github.com/fluent/fluent-plugin-s3/issues/208
-  #
-  # This plugin is sometimes used with s3 plugin.
-  # Unless s3 plugin is updated to be available with v3,
-  # this plugin should depend on v2 only.
-  # spec.add_dependency "aws-sdk-kinesis", "~> 1"
-  # spec.add_dependency "aws-sdk-firehose", "~> 1"
+
+  # This plugin is sometimes used with s3 plugin, so watch out for conflicts
+  # https://rubygems.org/gems/fluent-plugin-s3
+  spec.add_dependency "aws-sdk-kinesis", "~> 1"
+  spec.add_dependency "aws-sdk-firehose", "~> 1"
+
   spec.add_dependency "google-protobuf", "~> 3"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/gemfiles/Gemfile.td-agent-3.2.0
+++ b/gemfiles/Gemfile.td-agent-3.2.0
@@ -17,9 +17,15 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
 gemspec path: ".."
 
-# Specify related gems for td-agent v2.3.5
-# https://github.com/treasure-data/omnibus-td-agent/blob/release-2.3.5/config/projects/td-agent2.rb#L23
-gem "fluentd", "0.12.35"
-# https://github.com/treasure-data/omnibus-td-agent/blob/release-2.3.5/plugin_gems.rb#L13-L15
-gem "fluent-plugin-s3", "0.8.2"
-gem "aws-sdk", "2.9.9"
+# Specify related gems for td-agent v3.2.0
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L27
+gem "fluentd", "1.2.2"
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/plugin_gems.rb#L16-L23
+gem "jmespath", "1.4.0"
+gem "aws-partitions", "1.87.0"
+gem "aws-sigv4", "1.0.2"
+gem "aws-sdk-core", "3.21.2"
+gem "aws-sdk-kms", "1.5.0"
+gem "aws-sdk-sqs", "1.3.0"
+gem "aws-sdk-s3", "1.13.0"
+gem "fluent-plugin-s3", "1.1.3"


### PR DESCRIPTION
removes a ton of dependencies when installing https://rubygems.org/gems/fluent-plugin-s3

@riywo @adammw

⚠️note-to-self do not force-push since we use that commit ⚠️ 