### PR TITLE
 Remove support for fluentd v0.12 and use new Plugin API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: ruby
+os: linux
+sudo: false
 
 matrix:
   include:
     - rvm: 2.4.1
-      os: linux
       gemfile: Gemfile
-    - rvm: 2.1.10
-      os: linux
-      gemfile: gemfiles/Gemfile.td-agent-2.3.5
+    - rvm: 2.4.4 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L22
+      gemfile: gemfiles/Gemfile.td-agent-3.2.0
 
 script: bundle exec rake test
-
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
   include:
     - rvm: 2.4.1
       gemfile: Gemfile
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile.fluentd-0.14.10
     - rvm: 2.4.4 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L22
       gemfile: gemfiles/Gemfile.td-agent-3.2.0
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or just download specify your Ruby library path. Below is the sample for specify
 
 ## Dependencies
  * Ruby 2.1.0+
- * Fluentd 0.14.0+
+ * Fluentd 0.14.10+
 
 ## Basic Usage
 Here are general procedures for using this plugin:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or just download specify your Ruby library path. Below is the sample for specify
 
 ## Dependencies
  * Ruby 2.1.0+
- * Fluentd 0.12.35+ (supporting 0.14.x)
+ * Fluentd 0.14.0+
 
 ## Basic Usage
 Here are general procedures for using this plugin:

--- a/benchmark/task.rake
+++ b/benchmark/task.rake
@@ -78,11 +78,11 @@ class KinesisBenchmark
   def create_driver(type, conf = default_config)
     klass = case type
             when :streams
-              Fluent::KinesisStreamsOutput
+              Fluent::Plugin::KinesisStreamsOutput
             when :streams_aggregated
-              Fluent::KinesisStreamsAggregatedOutput
+              Fluent::Plugin::KinesisStreamsAggregatedOutput
             when :firehose
-              Fluent::KinesisFirehoseOutput
+              Fluent::Plugin::KinesisFirehoseOutput
             end
     conf += case type
             when :streams, :streams_aggregated
@@ -90,13 +90,9 @@ class KinesisBenchmark
             when :firehose
               "delivery_stream_name fluent-plugin-test"
             end
-    if fluentd_v0_12?
-      Fluent::Test::BufferedOutputTestDriver.new(klass) do
-      end.configure(conf)
-    else
-      Fluent::Test::Driver::Output.new(klass) do
-      end.configure(conf)
-    end
+
+    Fluent::Test::Driver::Output.new(klass) do
+    end.configure(conf)
   end
 
   def benchmark(size, count)

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -31,15 +31,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency "fluentd", ">= 0.12.35", "< 2"
-  spec.add_dependency "aws-sdk", ">= 2.9.9", "< 4"
-  # TODO: fluent-plugin-s3 depends on v2 only.
-  # https://github.com/fluent/fluent-plugin-s3/issues/208
-  #
-  # This plugin is sometimes used with s3 plugin.
-  # Unless s3 plugin is updated to be available with v3,
-  # this plugin should depend on v2 only.
-  # spec.add_dependency "aws-sdk-kinesis", "~> 1"
-  # spec.add_dependency "aws-sdk-firehose", "~> 1"
+
+  # This plugin is sometimes used with s3 plugin, so watch out for conflicts
+  # https://rubygems.org/gems/fluent-plugin-s3
+  spec.add_dependency "aws-sdk-kinesis", "~> 1"
+  spec.add_dependency "aws-sdk-firehose", "~> 1"
+
   spec.add_dependency "google-protobuf", "~> 3"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency "fluentd", ">= 0.12.35", "< 2"
+  spec.add_dependency "fluentd", ">= 0.14.0", "< 2"
 
   # This plugin is sometimes used with s3 plugin, so watch out for conflicts
   # https://rubygems.org/gems/fluent-plugin-s3

--- a/gemfiles/Gemfile.fluentd-0.14.10
+++ b/gemfiles/Gemfile.fluentd-0.14.10
@@ -1,0 +1,20 @@
+#
+# Copyright 2014-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
+gemspec path: ".."
+
+gem "fluentd", "0.14.10"

--- a/gemfiles/Gemfile.td-agent-3.2.0
+++ b/gemfiles/Gemfile.td-agent-3.2.0
@@ -17,9 +17,15 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
 gemspec path: ".."
 
-# Specify related gems for td-agent v2.3.5
-# https://github.com/treasure-data/omnibus-td-agent/blob/release-2.3.5/config/projects/td-agent2.rb#L23
-gem "fluentd", "0.12.35"
-# https://github.com/treasure-data/omnibus-td-agent/blob/release-2.3.5/plugin_gems.rb#L13-L15
-gem "fluent-plugin-s3", "0.8.2"
-gem "aws-sdk", "2.9.9"
+# Specify related gems for td-agent v3.2.0
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L27
+gem "fluentd", "1.2.2"
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/plugin_gems.rb#L16-L23
+gem "jmespath", "1.4.0"
+gem "aws-partitions", "1.87.0"
+gem "aws-sigv4", "1.0.2"
+gem "aws-sdk-core", "3.21.2"
+gem "aws-sdk-kms", "1.5.0"
+gem "aws-sdk-sqs", "1.3.0"
+gem "aws-sdk-s3", "1.13.0"
+gem "fluent-plugin-s3", "1.1.3"

--- a/lib/fluent/plugin/kinesis.rb
+++ b/lib/fluent/plugin/kinesis.rb
@@ -12,154 +12,134 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require 'fluent/plugin/output'
 require 'fluent/plugin/kinesis_helper/client'
 require 'fluent/plugin/kinesis_helper/api'
 require 'zlib'
 
 module Fluent
-  class KinesisOutput < BufferedOutput
-    def self.fluentd_v0_12?
-      @fluentd_v0_12 ||= Gem.loaded_specs['fluentd'].version < Gem::Version.create('0.14')
-    end
+  module Plugin
+    class KinesisOutput < Fluent::Plugin::Output
+      include Fluent::MessagePackFactory::Mixin
+      include KinesisHelper::Client
+      include KinesisHelper::API
 
-    include Fluent::SetTimeKeyMixin
-    include Fluent::SetTagKeyMixin
+      class SkipRecordError < ::StandardError
+        def initialize(message, record)
+          super message
+          @record_message = if record.is_a? Array
+                              record.reverse.map(&:to_s).join(', ')
+                            else
+                              record.to_s
+                            end
+        end
 
-    include KinesisHelper::Client
-    include KinesisHelper::API
-
-    class SkipRecordError < ::StandardError
-      def initialize(message, record)
-        super message
-        @record_message = if record.is_a? Array
-          record.reverse.map(&:to_s).join(', ')
-        else
-          record.to_s
+        def to_s
+          super + ": " + @record_message
+        end
+      end
+      class KeyNotFoundError < SkipRecordError
+        def initialize(key, record)
+          super "Key '#{key}' doesn't exist", record
+        end
+      end
+      class ExceedMaxRecordSizeError < SkipRecordError
+        def initialize(size, record)
+          super "Record size limit exceeded in #{size/1024} KB", record
+        end
+      end
+      class InvalidRecordError < SkipRecordError
+        def initialize(record)
+          super "Invalid type of record", record
         end
       end
 
-      def to_s
-        super + ": " + @record_message
+      config_param :data_key,              :string,  default: nil
+      config_param :log_truncate_max_size, :integer, default: 1024
+      config_param :compression,           :string,  default: nil
+      config_section :format do
+        config_set_default :@type, 'json'
       end
-    end
-    class KeyNotFoundError < SkipRecordError
-      def initialize(key, record)
-        super "Key '#{key}' doesn't exist", record
+      config_section :inject do
+        config_set_default :time_type, 'string'
+        config_set_default :time_format, '%Y-%m-%dT%H:%M:%S.%N%z'
       end
-    end
-    class ExceedMaxRecordSizeError < SkipRecordError
-      def initialize(size, record)
-        super "Record size limit exceeded in #{size/1024} KB", record
-      end
-    end
-    class InvalidRecordError < SkipRecordError
-      def initialize(record)
-        super "Invalid type of record", record
-      end
-    end
 
-    config_param :data_key,              :string,  default: nil
-    config_param :log_truncate_max_size, :integer, default: 1024
-    config_param :compression,           :string,  default: nil
-    config_section :format do
-      config_set_default :@type, 'json'
-    end
-    config_section :inject do
-      config_set_default :time_type, 'string'
-      config_set_default :time_format, '%Y-%m-%dT%H:%M:%S.%N%z'
-    end
+      config_param :debug, :bool, default: false
 
-    config_param :debug, :bool, default: false
-
-    if fluentd_v0_12?
-      config_param :format, :string,  default: 'json'
-    else
       helpers :formatter, :inject
-    end
 
-    def configure(conf)
-      super
-      @data_formatter = data_formatter_create(conf)
-    end
+      def configure(conf)
+        super
+        @data_formatter = data_formatter_create(conf)
+      end
 
-    def multi_workers_ready?
-      true
-    end
+      def multi_workers_ready?
+        true
+      end
 
-    private
+      private
 
-    def fluentd_v0_12?
-      self.class.fluentd_v0_12?
-    end
-
-    def data_formatter_create(conf)
-      if fluentd_v0_12?
-        formatter = Fluent::Plugin.new_formatter(@format)
-        formatter.configure(conf)
-      else
+      def data_formatter_create(conf)
         formatter = formatter_create
-      end
-      compressor = compressor_create
-      if @data_key.nil?
-        ->(tag, time, record) {
-          unless fluentd_v0_12?
+        compressor = compressor_create
+        if @data_key.nil?
+          ->(tag, time, record) {
             record = inject_values_to_record(tag, time, record)
-          end
-          compressor.call(formatter.format(tag, time, record).chomp.b)
-        }
-      else
-        ->(tag, time, record) {
-          raise InvalidRecordError, record unless record.is_a? Hash
-          raise KeyNotFoundError.new(@data_key, record) if record[@data_key].nil?
-          compressor.call(record[@data_key].to_s.b)
-        }
+            compressor.call(formatter.format(tag, time, record).chomp.b)
+          }
+        else
+          ->(tag, time, record) {
+            raise InvalidRecordError, record unless record.is_a? Hash
+            raise KeyNotFoundError.new(@data_key, record) if record[@data_key].nil?
+            compressor.call(record[@data_key].to_s.b)
+          }
+        end
       end
-    end
 
-    def compressor_create
-      case @compression
-      when "zlib"
-        ->(data) { Zlib::Deflate.deflate(data) }
-      else
-        ->(data) { data }
+      def compressor_create
+        case @compression
+        when "zlib"
+          ->(data) { Zlib::Deflate.deflate(data) }
+        else
+          ->(data) { data }
+        end
       end
-    end
 
-    def format_for_api(&block)
-      converted = block.call
-      size = size_of_values(converted)
-      if size > @max_record_size
-        raise ExceedMaxRecordSizeError.new(size, converted)
+      def format_for_api(&block)
+        converted = block.call
+        size = size_of_values(converted)
+        if size > @max_record_size
+          raise ExceedMaxRecordSizeError.new(size, converted)
+        end
+        converted.to_msgpack
+      rescue SkipRecordError => e
+        log.error(truncate e)
+        ''
       end
-      converted.to_msgpack
-    rescue SkipRecordError => e
-      log.error(truncate e)
-      ''
-    end
 
-    def write_records_batch(chunk, &block)
-      if fluentd_v0_12?
-        unique_id = chunk.unique_id.unpack('H*').first
-      else
+      def write_records_batch(chunk, &block)
         unique_id = chunk.dump_unique_id_hex(chunk.unique_id)
+        chunk.open do |io|
+          records = msgpack_unpacker(io).to_enum
+          split_to_batches(records) do |batch, size|
+            log.debug(sprintf "Write chunk %s / %3d records / %4d KB", unique_id, batch.size, size/1024)
+            batch_request_with_retry(batch, &block)
+            log.debug("Finish writing chunk")
+          end
+        end
       end
-      records = chunk.to_enum(:msgpack_each)
-      split_to_batches(records) do |batch, size|
-        log.debug(sprintf "Write chunk %s / %3d records / %4d KB", unique_id, batch.size, size/1024)
-        batch_request_with_retry(batch, &block)
-        log.debug("Finish writing chunk")
+
+      def request_type
+        self.class::RequestType
       end
-    end
 
-    def request_type
-      self.class::RequestType
-    end
-
-    def truncate(msg)
-      if @log_truncate_max_size == 0 or (msg.to_s.size <= @log_truncate_max_size)
-        msg.to_s
-      else
-        msg.to_s[0...@log_truncate_max_size]
+      def truncate(msg)
+        if @log_truncate_max_size == 0 or (msg.to_s.size <= @log_truncate_max_size)
+          msg.to_s
+        else
+          msg.to_s[0...@log_truncate_max_size]
+        end
       end
     end
   end

--- a/lib/fluent/plugin/kinesis_helper/api.rb
+++ b/lib/fluent/plugin/kinesis_helper/api.rb
@@ -16,178 +16,180 @@ require 'fluent_plugin_kinesis/version'
 require 'fluent/configurable'
 
 module Fluent
-  module KinesisHelper
-    module API
-      MaxRecordSize = 1024 * 1024 # 1 MB
+  module Plugin
+    module KinesisHelper
+      module API
+        MaxRecordSize = 1024 * 1024 # 1 MB
 
-      module APIParams
-        include Fluent::Configurable
-        config_param :max_record_size, :integer, default: MaxRecordSize
-      end
-
-      def self.included(mod)
-        mod.include APIParams
-      end
-
-      def configure(conf)
-        super
-        if @max_record_size > MaxRecordSize
-          raise ConfigError, "max_record_size can't be grater than #{MaxRecordSize/1024} KB."
-        end
-      end
-
-      module BatchRequest
-        module BatchRequestParams
+        module APIParams
           include Fluent::Configurable
-          config_param :retries_on_batch_request, :integer, default: 8
-          config_param :reset_backoff_if_success, :bool,    default: true
-          config_param :batch_request_max_count,  :integer, default: nil
-          config_param :batch_request_max_size,   :integer, default: nil
+          config_param :max_record_size, :integer, default: MaxRecordSize
         end
 
         def self.included(mod)
-          mod.include BatchRequestParams
+          mod.include APIParams
         end
 
         def configure(conf)
           super
-          if @batch_request_max_count.nil?
-            @batch_request_max_count = self.class::BatchRequestLimitCount
-          elsif @batch_request_max_count > self.class::BatchRequestLimitCount
-            raise ConfigError, "batch_request_max_count can't be grater than #{self.class::BatchRequestLimitCount}."
-          end
-          if @batch_request_max_size.nil?
-            @batch_request_max_size = self.class::BatchRequestLimitSize
-          elsif @batch_request_max_size > self.class::BatchRequestLimitSize
-            raise ConfigError, "batch_request_max_size can't be grater than #{self.class::BatchRequestLimitSize}."
+          if @max_record_size > MaxRecordSize
+            raise ConfigError, "max_record_size can't be grater than #{MaxRecordSize/1024} KB."
           end
         end
 
-        def size_of_values(record)
-          record.compact.map(&:size).inject(:+) || 0
-        end
-
-        private
-
-        def split_to_batches(records, &block)
-          batch = []
-          size = 0
-          records.each do |record|
-            record_size = size_of_values(record)
-            if batch.size+1 > @batch_request_max_count or size+record_size > @batch_request_max_size
-              yield(batch, size)
-              batch = []
-              size = 0
-	    end
-            batch << record
-            size += record_size
+        module BatchRequest
+          module BatchRequestParams
+            include Fluent::Configurable
+            config_param :retries_on_batch_request, :integer, default: 8
+            config_param :reset_backoff_if_success, :bool,    default: true
+            config_param :batch_request_max_count,  :integer, default: nil
+            config_param :batch_request_max_size,   :integer, default: nil
           end
-          yield(batch, size) if batch.size > 0
-        end
 
-        def batch_request_with_retry(batch, retry_count=0, backoff: nil, &block)
-          backoff ||= Backoff.new
-          res = yield(batch)
-          if failed_count(res) > 0
-            failed_records = collect_failed_records(batch, res)
-            if retry_count < @retries_on_batch_request
-              backoff.reset if @reset_backoff_if_success and any_records_shipped?(res)
-              wait_second = backoff.next
-              msg = 'Retrying to request batch. Retry count: %3d, Retry records: %3d, Wait seconds %3.2f' % [retry_count+1, failed_records.size, wait_second]
-              log.warn(truncate msg)
-              # TODO: sleep() doesn't wait the given seconds sometime.
-              # The root cause is unknown so far, so I'd like to add debug print only. It should be fixed in the future.
-              log.debug("#{Thread.current.object_id} sleep start")
-              sleep(wait_second)
-              log.debug("#{Thread.current.object_id} sleep finish")
-              batch_request_with_retry(retry_records(failed_records), retry_count+1, backoff: backoff, &block)
-            else
-              give_up_retries(failed_records)
+          def self.included(mod)
+            mod.include BatchRequestParams
+          end
+
+          def configure(conf)
+            super
+            if @batch_request_max_count.nil?
+              @batch_request_max_count = self.class::BatchRequestLimitCount
+            elsif @batch_request_max_count > self.class::BatchRequestLimitCount
+              raise ConfigError, "batch_request_max_count can't be grater than #{self.class::BatchRequestLimitCount}."
+            end
+            if @batch_request_max_size.nil?
+              @batch_request_max_size = self.class::BatchRequestLimitSize
+            elsif @batch_request_max_size > self.class::BatchRequestLimitSize
+              raise ConfigError, "batch_request_max_size can't be grater than #{self.class::BatchRequestLimitSize}."
             end
           end
-        end
 
-        def any_records_shipped?(res)
-          results(res).size > failed_count(res)
-        end
-
-        def collect_failed_records(records, res)
-          failed_records = []
-          results(res).each_with_index do |record, index|
-            next unless record[:error_code]
-            original = case request_type
-                       when :streams, :firehose; records[index]
-                       when :streams_aggregated; records
-                       end
-            failed_records.push(
-              original:      original,
-              error_code:    record[:error_code],
-              error_message: record[:error_message]
-            )
-          end
-          failed_records
-        end
-
-        def retry_records(failed_records)
-          case request_type
-          when :streams, :firehose
-            failed_records.map{|r| r[:original] }
-          when :streams_aggregated
-            failed_records.first[:original]
-          end
-        end
-
-        def failed_count(res)
-          failed_field = case request_type
-                         when :streams;            :failed_record_count
-                         when :streams_aggregated; :failed_record_count
-                         when :firehose;           :failed_put_count
-                         end
-          res[failed_field]
-        end
-
-        def results(res)
-          result_field = case request_type
-                         when :streams;            :records
-                         when :streams_aggregated; :records
-                         when :firehose;           :request_responses
-                         end
-          res[result_field]
-        end
-
-        def give_up_retries(failed_records)
-          failed_records.each {|record|
-            log.error(truncate 'Could not put record, Error: %s/%s, Record: %s' % [
-              record[:error_code],
-              record[:error_message],
-              record[:original]
-            ])
-          }
-        end
-
-        class Backoff
-          def initialize
-            @count = 0
-          end
-
-          def next
-            value = calc(@count)
-            @count += 1
-            value
-          end
-
-          def reset
-            @count = 0
+          def size_of_values(record)
+            record.compact.map(&:size).inject(:+) || 0
           end
 
           private
 
-          def calc(count)
-            (2 ** count) * scaling_factor
+          def split_to_batches(records, &block)
+            batch = []
+            size = 0
+            records.each do |record|
+              record_size = size_of_values(record)
+              if batch.size+1 > @batch_request_max_count or size+record_size > @batch_request_max_size
+                yield(batch, size)
+                batch = []
+                size = 0
+        end
+              batch << record
+              size += record_size
+            end
+            yield(batch, size) if batch.size > 0
           end
 
-          def scaling_factor
-            0.3 + (0.5-rand) * 0.1
+          def batch_request_with_retry(batch, retry_count=0, backoff: nil, &block)
+            backoff ||= Backoff.new
+            res = yield(batch)
+            if failed_count(res) > 0
+              failed_records = collect_failed_records(batch, res)
+              if retry_count < @retries_on_batch_request
+                backoff.reset if @reset_backoff_if_success and any_records_shipped?(res)
+                wait_second = backoff.next
+                msg = 'Retrying to request batch. Retry count: %3d, Retry records: %3d, Wait seconds %3.2f' % [retry_count+1, failed_records.size, wait_second]
+                log.warn(truncate msg)
+                # TODO: sleep() doesn't wait the given seconds sometime.
+                # The root cause is unknown so far, so I'd like to add debug print only. It should be fixed in the future.
+                log.debug("#{Thread.current.object_id} sleep start")
+                sleep(wait_second)
+                log.debug("#{Thread.current.object_id} sleep finish")
+                batch_request_with_retry(retry_records(failed_records), retry_count+1, backoff: backoff, &block)
+              else
+                give_up_retries(failed_records)
+              end
+            end
+          end
+
+          def any_records_shipped?(res)
+            results(res).size > failed_count(res)
+          end
+
+          def collect_failed_records(records, res)
+            failed_records = []
+            results(res).each_with_index do |record, index|
+              next unless record[:error_code]
+              original = case request_type
+                         when :streams, :firehose; records[index]
+                         when :streams_aggregated; records
+                         end
+              failed_records.push(
+                original:      original,
+                error_code:    record[:error_code],
+                error_message: record[:error_message]
+              )
+            end
+            failed_records
+          end
+
+          def retry_records(failed_records)
+            case request_type
+            when :streams, :firehose
+              failed_records.map{|r| r[:original] }
+            when :streams_aggregated
+              failed_records.first[:original]
+            end
+          end
+
+          def failed_count(res)
+            failed_field = case request_type
+                           when :streams;            :failed_record_count
+                           when :streams_aggregated; :failed_record_count
+                           when :firehose;           :failed_put_count
+                           end
+            res[failed_field]
+          end
+
+          def results(res)
+            result_field = case request_type
+                           when :streams;            :records
+                           when :streams_aggregated; :records
+                           when :firehose;           :request_responses
+                           end
+            res[result_field]
+          end
+
+          def give_up_retries(failed_records)
+            failed_records.each {|record|
+              log.error(truncate 'Could not put record, Error: %s/%s, Record: %s' % [
+                record[:error_code],
+                record[:error_message],
+                record[:original]
+              ])
+            }
+          end
+
+          class Backoff
+            def initialize
+              @count = 0
+            end
+
+            def next
+              value = calc(@count)
+              @count += 1
+              value
+            end
+
+            def reset
+              @count = 0
+            end
+
+            private
+
+            def calc(count)
+              (2 ** count) * scaling_factor
+            end
+
+            def scaling_factor
+              0.3 + (0.5-rand) * 0.1
+            end
           end
         end
       end

--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -16,152 +16,154 @@ require 'fluent/configurable'
 require 'aws-sdk-core'
 
 module Fluent
-  module KinesisHelper
-    module Client
-      module ClientParams
-        include Fluent::Configurable
-        config_param :region, :string,  default: nil
+  module Plugin
+    module KinesisHelper
+      module Client
+        module ClientParams
+          include Fluent::Configurable
+          config_param :region, :string,  default: nil
 
-        config_param :http_proxy,      :string, default: nil, secret: true
-        config_param :endpoint,        :string, default: nil
-        config_param :ssl_verify_peer, :bool,   default: true
+          config_param :http_proxy,      :string, default: nil, secret: true
+          config_param :endpoint,        :string, default: nil
+          config_param :ssl_verify_peer, :bool,   default: true
 
-        config_param :aws_key_id,  :string, default: nil, secret: true
-        config_param :aws_sec_key, :string, default: nil, secret: true
-        config_section :assume_role_credentials, multi: false do
-          desc "The Amazon Resource Name (ARN) of the role to assume"
-          config_param :role_arn, :string, secret: true
-          desc "An identifier for the assumed role session"
-          config_param :role_session_name, :string
-          desc "An IAM policy in JSON format"
-          config_param :policy, :string, default: nil
-          desc "The duration, in seconds, of the role session (900-3600)"
-          config_param :duration_seconds, :integer, default: nil
-          desc "A unique identifier that is used by third parties when assuming roles in their customers' accounts."
-          config_param :external_id, :string, default: nil, secret: true
-          desc "A http proxy url for requests to aws sts service"
-          config_param :sts_http_proxy, :string, default: nil, secret: true
+          config_param :aws_key_id,  :string, default: nil, secret: true
+          config_param :aws_sec_key, :string, default: nil, secret: true
+          config_section :assume_role_credentials, multi: false do
+            desc "The Amazon Resource Name (ARN) of the role to assume"
+            config_param :role_arn, :string, secret: true
+            desc "An identifier for the assumed role session"
+            config_param :role_session_name, :string
+            desc "An IAM policy in JSON format"
+            config_param :policy, :string, default: nil
+            desc "The duration, in seconds, of the role session (900-3600)"
+            config_param :duration_seconds, :integer, default: nil
+            desc "A unique identifier that is used by third parties when assuming roles in their customers' accounts."
+            config_param :external_id, :string, default: nil, secret: true
+            desc "A http proxy url for requests to aws sts service"
+            config_param :sts_http_proxy, :string, default: nil, secret: true
+          end
+          config_section :instance_profile_credentials, multi: false do
+            desc "Number of times to retry when retrieving credentials"
+            config_param :retries, :integer, default: nil
+            desc "IP address (default:169.254.169.254)"
+            config_param :ip_address, :string, default: nil
+            desc "Port number (default:80)"
+            config_param :port, :integer, default: nil
+            desc "Number of seconds to wait for the connection to open"
+            config_param :http_open_timeout, :float, default: nil
+            desc "Number of seconds to wait for one block to be read"
+            config_param :http_read_timeout, :float, default: nil
+            # config_param :delay, :integer or :proc, :default => nil
+            # config_param :http_degub_output, :io, :default => nil
+          end
+          config_section :shared_credentials, multi: false do
+            desc "Path to the shared file. (default: $HOME/.aws/credentials)"
+            config_param :path, :string, default: nil
+            desc "Profile name. Default to 'default' or ENV['AWS_PROFILE']"
+            config_param :profile_name, :string, default: nil
+          end
         end
-        config_section :instance_profile_credentials, multi: false do
-          desc "Number of times to retry when retrieving credentials"
-          config_param :retries, :integer, default: nil
-          desc "IP address (default:169.254.169.254)"
-          config_param :ip_address, :string, default: nil
-          desc "Port number (default:80)"
-          config_param :port, :integer, default: nil
-          desc "Number of seconds to wait for the connection to open"
-          config_param :http_open_timeout, :float, default: nil
-          desc "Number of seconds to wait for one block to be read"
-          config_param :http_read_timeout, :float, default: nil
-          # config_param :delay, :integer or :proc, :default => nil
-          # config_param :http_degub_output, :io, :default => nil
+
+        def self.included(mod)
+          mod.include ClientParams
         end
-        config_section :shared_credentials, multi: false do
-          desc "Path to the shared file. (default: $HOME/.aws/credentials)"
-          config_param :path, :string, default: nil
-          desc "Profile name. Default to 'default' or ENV['AWS_PROFILE']"
-          config_param :profile_name, :string, default: nil
+
+        def configure(conf)
+          super
+          @region = client.config.region if @region.nil?
         end
-      end
 
-      def self.included(mod)
-        mod.include ClientParams
-      end
+        def client
+          @client ||= client_class.new(client_options)
+        end
 
-      def configure(conf)
-        super
-        @region = client.config.region if @region.nil?
-      end
+        private
 
-      def client
-        @client ||= client_class.new(client_options)
-      end
+        def aws_sdk_v2?
+          @aws_sdk_v2 ||= Gem.loaded_specs['aws-sdk-core'].version < Gem::Version.create('3')
+        end
 
-      private
+        def client_class
+          case request_type
+          when :streams, :streams_aggregated
+            if aws_sdk_v2?
+              require 'aws-sdk'
+            else
+              require 'aws-sdk-kinesis'
+            end
+            Aws::Kinesis::Client
+          when :firehose
+            if aws_sdk_v2?
+              require 'aws-sdk'
+            else
+              require 'aws-sdk-firehose'
+            end
+            Aws::Firehose::Client
+          end
+        end
 
-      def aws_sdk_v2?
-        @aws_sdk_v2 ||= Gem.loaded_specs['aws-sdk-core'].version < Gem::Version.create('3')
-      end
+        def client_options
+          options = setup_credentials
+          options.update(
+            user_agent_suffix: "fluent-plugin-kinesis/#{request_type}/#{FluentPluginKinesis::VERSION}"
+          )
+          options.update(region:          @region)          unless @region.nil?
+          options.update(http_proxy:      @http_proxy)      unless @http_proxy.nil?
+          options.update(endpoint:        @endpoint)        unless @endpoint.nil?
+          options.update(ssl_verify_peer: @ssl_verify_peer) unless @ssl_verify_peer.nil?
+          if @debug
+            options.update(logger: Logger.new(log.out))
+            options.update(log_level: :debug)
+          end
+          options
+        end
 
-      def client_class
-        case request_type
-        when :streams, :streams_aggregated
-          if aws_sdk_v2?
-            require 'aws-sdk'
+        def setup_credentials
+          options = {}
+          credentials_options = {}
+          case
+          when @aws_key_id && @aws_sec_key
+            options[:access_key_id] = @aws_key_id
+            options[:secret_access_key] = @aws_sec_key
+          when @assume_role_credentials
+            c = @assume_role_credentials
+            credentials_options[:role_arn] = c.role_arn
+            credentials_options[:role_session_name] = c.role_session_name
+            credentials_options[:policy] = c.policy if c.policy
+            credentials_options[:duration_seconds] = c.duration_seconds if c.duration_seconds
+            credentials_options[:external_id] = c.external_id if c.external_id
+            if c.sts_http_proxy and @region
+                credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)
+            elsif @region
+                credentials_options[:client] = Aws::STS::Client.new(region: @region)
+            elsif c.sts_http_proxy
+                credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy)
+            end
+            options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
+          when @instance_profile_credentials
+            c = @instance_profile_credentials
+            credentials_options[:retries] = c.retries if c.retries
+            credentials_options[:ip_address] = c.ip_address if c.ip_address
+            credentials_options[:port] = c.port if c.port
+            credentials_options[:http_open_timeout] = c.http_open_timeout if c.http_open_timeout
+            credentials_options[:http_read_timeout] = c.http_read_timeout if c.http_read_timeout
+            if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+              options[:credentials] = Aws::ECSCredentials.new(credentials_options)
+            else
+              options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
+            end
+          when @shared_credentials
+            c = @shared_credentials
+            credentials_options[:path] = c.path if c.path
+            credentials_options[:profile_name] = c.profile_name if c.profile_name
+            options[:credentials] = Aws::SharedCredentials.new(credentials_options)
           else
-            require 'aws-sdk-kinesis'
+            # Use default credentials
+            # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html
           end
-          Aws::Kinesis::Client
-        when :firehose
-          if aws_sdk_v2?
-            require 'aws-sdk'
-          else
-            require 'aws-sdk-firehose'
-          end
-          Aws::Firehose::Client
+          options
         end
-      end
-
-      def client_options
-        options = setup_credentials
-        options.update(
-          user_agent_suffix: "fluent-plugin-kinesis/#{request_type}/#{FluentPluginKinesis::VERSION}"
-        )
-        options.update(region:          @region)          unless @region.nil?
-        options.update(http_proxy:      @http_proxy)      unless @http_proxy.nil?
-        options.update(endpoint:        @endpoint)        unless @endpoint.nil?
-        options.update(ssl_verify_peer: @ssl_verify_peer) unless @ssl_verify_peer.nil?
-        if @debug
-          options.update(logger: Logger.new(log.out))
-          options.update(log_level: :debug)
-        end
-        options
-      end
-
-      def setup_credentials
-        options = {}
-        credentials_options = {}
-        case
-        when @aws_key_id && @aws_sec_key
-          options[:access_key_id] = @aws_key_id
-          options[:secret_access_key] = @aws_sec_key
-        when @assume_role_credentials
-          c = @assume_role_credentials
-          credentials_options[:role_arn] = c.role_arn
-          credentials_options[:role_session_name] = c.role_session_name
-          credentials_options[:policy] = c.policy if c.policy
-          credentials_options[:duration_seconds] = c.duration_seconds if c.duration_seconds
-          credentials_options[:external_id] = c.external_id if c.external_id
-          if c.sts_http_proxy and @region
-              credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)
-          elsif @region
-              credentials_options[:client] = Aws::STS::Client.new(region: @region)
-          elsif c.sts_http_proxy
-              credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy)
-          end
-          options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
-        when @instance_profile_credentials
-          c = @instance_profile_credentials
-          credentials_options[:retries] = c.retries if c.retries
-          credentials_options[:ip_address] = c.ip_address if c.ip_address
-          credentials_options[:port] = c.port if c.port
-          credentials_options[:http_open_timeout] = c.http_open_timeout if c.http_open_timeout
-          credentials_options[:http_read_timeout] = c.http_read_timeout if c.http_read_timeout
-          if ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
-            options[:credentials] = Aws::ECSCredentials.new(credentials_options)
-          else
-            options[:credentials] = Aws::InstanceProfileCredentials.new(credentials_options)
-          end
-        when @shared_credentials
-          c = @shared_credentials
-          credentials_options[:path] = c.path if c.path
-          credentials_options[:profile_name] = c.profile_name if c.profile_name
-          options[:credentials] = Aws::SharedCredentials.new(credentials_options)
-        else
-          # Use default credentials
-          # See http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html
-        end
-        options
       end
     end
   end

--- a/test/dummy_server.rb
+++ b/test/dummy_server.rb
@@ -41,7 +41,7 @@ class DummyServer
     @failed_count = 0
     @error_count = 0
     @server, @port = init_server(port)
-    @aggregator = Fluent::KinesisHelper::Aggregator.new
+    @aggregator = Fluent::Plugin::KinesisHelper::Aggregator.new
     @recording = true
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,28 +15,18 @@
 require 'aws-sdk-core'
 require 'fluent/test'
 require 'fluent/test/helpers'
-def fluentd_v0_12?
-  @fluentd_v0_12 ||= Gem.loaded_specs['fluentd'].version < Gem::Version.create('0.14')
-end
 def aws_sdk_v2?
   @aws_sdk_v2 ||= Gem.loaded_specs['aws-sdk-core'].version < Gem::Version.create('3')
 end
 def driver_run(d, records, time: nil)
   time ||= event_time("2011-01-02 13:14:15 UTC")
-  if fluentd_v0_12?
-    records.each{|record| d.emit(record, time)}
-    d.run
-  else
-    d.instance.log.out.flush_logs = false
-    d.run(default_tag: "test") do
-      records.each{|record| d.feed(time, record)}
-    end
+  d.instance.log.out.flush_logs = false
+  d.run(default_tag: "test") do
+    records.each{|record| d.feed(time, record)}
   end
 end
-if !fluentd_v0_12?
-  require 'fluent/test/log'
-  require 'fluent/test/driver/output'
-end
+require 'fluent/test/log'
+require 'fluent/test/driver/output'
 if aws_sdk_v2?
   require 'aws-sdk'
 else

--- a/test/kinesis_helper/test_aggregator.rb
+++ b/test/kinesis_helper/test_aggregator.rb
@@ -16,11 +16,11 @@ require_relative '../helper'
 require 'fluent/plugin/kinesis_helper/aggregator'
 
 class KinesisHelperAggregatorTest < Test::Unit::TestCase
-  AggregateOffset = Fluent::KinesisHelper::Aggregator::Mixin::AggregateOffset
-  RecordOffset = Fluent::KinesisHelper::Aggregator::Mixin::RecordOffset
+  AggregateOffset = Fluent::Plugin::KinesisHelper::Aggregator::Mixin::AggregateOffset
+  RecordOffset = Fluent::Plugin::KinesisHelper::Aggregator::Mixin::RecordOffset
 
   def setup
-    @aggregator = Fluent::KinesisHelper::Aggregator.new
+    @aggregator = Fluent::Plugin::KinesisHelper::Aggregator.new
   end
 
   def teardown

--- a/test/kinesis_helper/test_api.rb
+++ b/test/kinesis_helper/test_api.rb
@@ -17,8 +17,8 @@ require 'fluent/plugin/kinesis_helper/api'
 
 class KinesisHelperAPITest < Test::Unit::TestCase
   class Mock
-    include Fluent::KinesisHelper::API
-    include Fluent::KinesisHelper::API::BatchRequest
+    include Fluent::Plugin::KinesisHelper::API
+    include Fluent::Plugin::KinesisHelper::API::BatchRequest
 
     attr_accessor :retries_on_batch_request, :reset_backoff_if_success
     attr_accessor :failed_scenario, :request_series

--- a/test/kinesis_helper/test_client.rb
+++ b/test/kinesis_helper/test_client.rb
@@ -17,7 +17,7 @@ require 'fluent/plugin/kinesis_helper/client'
 
 class KinesisHelperClientTest < Test::Unit::TestCase
   class Mock
-    include Fluent::KinesisHelper::Client
+    include Fluent::Plugin::KinesisHelper::Client
 
     def initialize
       @region = 'us-east-1'

--- a/test/plugin/test_out_kinesis_firehose.rb
+++ b/test/plugin/test_out_kinesis_firehose.rb
@@ -46,13 +46,8 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = default_config)
-    if fluentd_v0_12?
-      Fluent::Test::BufferedOutputTestDriver.new(Fluent::KinesisFirehoseOutput) do
-      end.configure(conf)
-    else
-      Fluent::Test::Driver::Output.new(Fluent::KinesisFirehoseOutput) do
-      end.configure(conf)
-    end
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::KinesisFirehoseOutput) do
+    end.configure(conf)
   end
 
   def self.data_of(size, char = 'a')
@@ -81,7 +76,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
   )
   def test_format(data)
     formatter, expected = data
-    d = create_driver(default_config + "format #{formatter}")
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
     assert_equal expected, @server.records.first
   end
@@ -92,7 +87,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
   )
   def test_format_without_append_new_line(data)
     formatter, expected = data
-    d = create_driver(default_config + "format #{formatter}\nappend_new_line false")
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nappend_new_line false")
     driver_run(d, [{"a"=>1,"b"=>2}])
     assert_equal expected, @server.records.first
   end

--- a/test/plugin/test_out_kinesis_streams.rb
+++ b/test/plugin/test_out_kinesis_streams.rb
@@ -46,13 +46,8 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = default_config)
-    if fluentd_v0_12?
-      Fluent::Test::BufferedOutputTestDriver.new(Fluent::KinesisStreamsOutput) do
-      end.configure(conf)
-    else
-      Fluent::Test::Driver::Output.new(Fluent::KinesisStreamsOutput) do
-      end.configure(conf)
-    end
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::KinesisStreamsOutput) do
+    end.configure(conf)
   end
 
   def self.data_of(size, char = 'a')
@@ -81,7 +76,7 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
   )
   def test_format(data)
     formatter, expected = data
-    d = create_driver(default_config + "format #{formatter}")
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
     assert_equal expected, @server.records.first
   end

--- a/test/plugin/test_out_kinesis_streams_aggregated.rb
+++ b/test/plugin/test_out_kinesis_streams_aggregated.rb
@@ -18,8 +18,8 @@ require 'fluent/plugin/out_kinesis_streams_aggregated'
 class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
   KB = 1024
   MB = 1024 * KB
-  AggregateOffset = Fluent::KinesisHelper::Aggregator::Mixin::AggregateOffset
-  RecordOffset = Fluent::KinesisHelper::Aggregator::Mixin::RecordOffset
+  AggregateOffset = Fluent::Plugin::KinesisHelper::Aggregator::Mixin::AggregateOffset
+  RecordOffset = Fluent::Plugin::KinesisHelper::Aggregator::Mixin::RecordOffset
 
   def setup
     ENV['AWS_REGION'] = 'ap-northeast-1'
@@ -47,13 +47,8 @@ class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = default_config)
-    if fluentd_v0_12?
-      Fluent::Test::BufferedOutputTestDriver.new(Fluent::KinesisStreamsAggregatedOutput) do
-      end.configure(conf)
-    else
-      Fluent::Test::Driver::Output.new(Fluent::KinesisStreamsAggregatedOutput) do
-      end.configure(conf)
-    end
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::KinesisStreamsAggregatedOutput) do
+    end.configure(conf)
   end
 
   def self.data_of(size, char = 'a')
@@ -82,7 +77,7 @@ class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
   )
   def test_format(data)
     formatter, expected = data
-    d = create_driver(default_config + "format #{formatter}")
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
     assert_equal expected, @server.records.first
   end


### PR DESCRIPTION
Fixes #155 and includes #152

There's a lot of code in this plugin to support the previous version of the fluentd plugin API. fluentd 0.14 has been out for two years now, hopefully most people can/have upgraded, and the cruft can be removed as a new major version of the plugin.

/cc @riywo 