### PR TITLE
Add aws session token as config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note: Each value should be adjusted to your system by yourself.
 ## Configuration: Credentials
 To put records into Amazon Kinesis Streams or Firehose, you need to provide AWS security credentials somehow. Without specifiying credentials in config file, this plugin automatically fetch credential just following AWS SDK for Ruby does (environment variable, shared profile, and instance profile).
 
-This plugin uses the same configuration in [fluent-plugin-s3][fluent-plugin-s3].
+This plugin uses the same configuration in [fluent-plugin-s3][fluent-plugin-s3], but also supports aws session tokens for temporary credentials. 
 
 **aws_key_id**
 
@@ -126,6 +126,10 @@ sure to configure `instance_profile_credentials`. Usage can be found below.
 
 AWS secret key. This parameter is required when your agent is not running
 on EC2 instance with an IAM Role.
+
+**aws_ses_token**
+
+AWS session token. This parameter is optional, but can be provided if using MFA or temporary credentials when your agent is not running on EC2 instance with an IAM Role. 
 
 **aws_iam_retries**
 

--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -29,6 +29,7 @@ module Fluent
 
           config_param :aws_key_id,  :string, default: nil, secret: true
           config_param :aws_sec_key, :string, default: nil, secret: true
+          config_param :aws_ses_token, :string, default: nil, secret: true
           config_section :assume_role_credentials, multi: false do
             desc "The Amazon Resource Name (ARN) of the role to assume"
             config_param :role_arn, :string, secret: true
@@ -123,6 +124,10 @@ module Fluent
           options = {}
           credentials_options = {}
           case
+          when @aws_key_id && @aws_sec_key && @aws_ses_token
+            options[:access_key_id] = @aws_key_id
+            options[:secret_access_key] = @aws_sec_key
+            options[:session_token] = @aws_ses_token  
           when @aws_key_id && @aws_sec_key
             options[:access_key_id] = @aws_key_id
             options[:secret_access_key] = @aws_sec_key


### PR DESCRIPTION
*Description of changes:*
* Added configuration parameter `aws_ses_token` for providing aws session token together with aws access key id and aws secret access key. 
* This makes it possible to use IAM with MFA and directly provide temporary credentials based on environment variables or file system.  
* See also related issue in #230 in aws-fluent-s3: https://github.com/fluent/fluent-plugin-s3/issues/230

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
