### PR TITLE
Remove chomp from internal formatter and add chomp_record option

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ Specifing compression way for data of each record. Current accepted options are 
 ### log_truncate_max_size
 Integer, default 1024. When emitting the log entry, the message will be truncated by this size to avoid infinite loop when the log is also sent to Kinesis. The value 0 means no truncation.
 
+### chomp_record
+Boolean. Default `false`. If it is enabled, formatter calls chomp and removes separator from the end of each record. This option is for compatible format with plugin v2.
+See [#142](https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/142) for more details.
+
 ## Configuraion: API
 ### region
 AWS region of your stream. It should be in form like `us-east-1`, `us-west-2`. Refer to [Regions and Endpoints in AWS General Reference][region] for supported regions.
@@ -351,7 +355,7 @@ Here are `kinesis_firehose` specific configurations.
 Name of the delivery stream to put data.
 
 ### append_new_line
-Boolean. Default `true`. If it is enabled, the plugin add new line character (`\n`) to each serialized record.
+Boolean. Default `true`. If it is enabled, the plugin add new line character (`\n`) to each serialized record. At first, the overridden formatter in the plugin calls chomp and removes separator from the end of each record. Then, it appends `\n` to each record.
 
 ## Configuration: kinesis_streams_aggregated
 Here are `kinesis_streams_aggregated` specific configurations.

--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ Specifing compression way for data of each record. Current accepted options are 
 Integer, default 1024. When emitting the log entry, the message will be truncated by this size to avoid infinite loop when the log is also sent to Kinesis. The value 0 means no truncation.
 
 ### chomp_record
-Boolean. Default `false`. If it is enabled, formatter calls chomp and removes separator from the end of each record. This option is for compatible format with plugin v2.
-See [#142](https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/142) for more details.
+Boolean. Default `false`. If it is enabled, the plugin calls chomp and removes separator from the end of each record. This option is for compatible format with plugin v2. See [#142](https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/142) for more details.  
+When you use [kinesis_firehose](#kinesis_firehose) output, [append_new_line](#append_new_line) option is `true` as default. If [append_new_line](#append_new_line) is enabled, the plugin calls chomp as [chomp_record](#chomp_record) is `true` before appending `\n` to each record. Therefore, you don't need to enable [chomp_record](#chomp_record) option when you use [kinesis_firehose](#kinesis_firehose) with default configuration. If you want to set [append_new_line](#append_new_line) `false`, you can choose [chomp_record](#chomp_record) `false` (default) or `true` (compatible format with plugin v2).
 
 ## Configuraion: API
 ### region
@@ -355,7 +355,8 @@ Here are `kinesis_firehose` specific configurations.
 Name of the delivery stream to put data.
 
 ### append_new_line
-Boolean. Default `true`. If it is enabled, the plugin add new line character (`\n`) to each serialized record. At first, the overridden formatter in the plugin calls chomp and removes separator from the end of each record. Then, it appends `\n` to each record.
+Boolean. Default `true`. If it is enabled, the plugin add new line character (`\n`) to each serialized record.  
+Before appending `\n`, plugin calls chomp and removes separator from the end of each record as [chomp_record](#chomp_record) is `true`. Therefore, you don't need to enable [chomp_record](#chomp_record) option when you use [kinesis_firehose](#kinesis_firehose) output with default configuration ([append_new_line](#append_new_line) is `true`). If you want to set [append_new_line](#append_new_line) `false`, you can choose [chomp_record](#chomp_record) `false` (default) or `true` (compatible format with plugin v2).
 
 ## Configuration: kinesis_streams_aggregated
 Here are `kinesis_streams_aggregated` specific configurations.

--- a/lib/fluent/plugin/kinesis.rb
+++ b/lib/fluent/plugin/kinesis.rb
@@ -57,6 +57,11 @@ module Fluent
       config_param :data_key,              :string,  default: nil
       config_param :log_truncate_max_size, :integer, default: 1024
       config_param :compression,           :string,  default: nil
+
+      desc "Formatter calls chomp and removes separator from the end of each record. This option is for compatible format with plugin v2. (default: false)"
+      # https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/142
+      config_param :chomp_record,          :bool,    default: false
+
       config_section :format do
         config_set_default :@type, 'json'
       end
@@ -84,12 +89,20 @@ module Fluent
         formatter = formatter_create
         compressor = compressor_create
         if @data_key.nil?
-          ->(tag, time, record) {
-            record = inject_values_to_record(tag, time, record)
-            # TODO Make option to chomp as compatible format with v2
-            # compressor.call(formatter.format(tag, time, record).chomp.b)
-            compressor.call(formatter.format(tag, time, record).b)
-          }
+          if @chomp_record
+            ->(tag, time, record) {
+              record = inject_values_to_record(tag, time, record)
+              # Formatter calls chomp and removes separator from the end of each record.
+              # This option is for compatible format with plugin v2.
+              # https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/142
+              compressor.call(formatter.format(tag, time, record).chomp.b)
+            }
+          else
+            ->(tag, time, record) {
+              record = inject_values_to_record(tag, time, record)
+              compressor.call(formatter.format(tag, time, record).b)
+            }
+          end
         else
           ->(tag, time, record) {
             raise InvalidRecordError, record unless record.is_a? Hash

--- a/lib/fluent/plugin/kinesis.rb
+++ b/lib/fluent/plugin/kinesis.rb
@@ -86,7 +86,9 @@ module Fluent
         if @data_key.nil?
           ->(tag, time, record) {
             record = inject_values_to_record(tag, time, record)
-            compressor.call(formatter.format(tag, time, record).chomp.b)
+            # TODO Make option to chomp as compatible format with v2
+            # compressor.call(formatter.format(tag, time, record).chomp.b)
+            compressor.call(formatter.format(tag, time, record).b)
           }
         else
           ->(tag, time, record) {

--- a/lib/fluent/plugin/out_kinesis_firehose.rb
+++ b/lib/fluent/plugin/out_kinesis_firehose.rb
@@ -32,7 +32,7 @@ module Fluent
         if @append_new_line
           org_data_formatter = @data_formatter
           @data_formatter = ->(tag, time, record) {
-            org_data_formatter.call(tag, time, record) + "\n"
+            org_data_formatter.call(tag, time, record).chomp + "\n"
           }
         end
       end

--- a/test/plugin/test_out_kinesis_firehose.rb
+++ b/test/plugin/test_out_kinesis_firehose.rb
@@ -71,14 +71,14 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
   end
 
   data(
-    'json' => ['json', "{\"a\":1,\"b\":2}\n"],
-    'ltsv' => ['ltsv', "a:1\tb:2\n"],
+    'json' => ['json', "{\"a\":1,\"b\":2}"],
+    'ltsv' => ['ltsv', "a:1\tb:2"],
   )
   def test_format(data)
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal expected, @server.records.first
+    assert_equal ("#{expected}\n" + "\n").b, @server.records.first
   end
 
   data(
@@ -89,7 +89,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nappend_new_line false")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal expected, @server.records.first
+    assert_equal "#{expected}\n".b, @server.records.first
   end
 
   def test_data_key
@@ -173,7 +173,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
     record = {"a" => "てすと"}
     driver_run(d, [record])
     assert_equal 0, d.instance.log.out.logs.size
-    assert_equal record.to_json.b + "\n", @server.records.first
+    assert_equal ("#{record.to_json}\n" + "\n").b, @server.records.first
   end
 
   def test_record_count

--- a/test/plugin/test_out_kinesis_firehose.rb
+++ b/test/plugin/test_out_kinesis_firehose.rb
@@ -78,7 +78,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal ("#{expected}\n" + "\n").b, @server.records.first
+    assert_equal (expected + "\n").b, @server.records.first
   end
 
   data(
@@ -89,7 +89,29 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nappend_new_line false")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal "#{expected}\n".b, @server.records.first
+    assert_equal (expected + "\n").b, @server.records.first
+  end
+
+  data(
+    'json' => ['json', '{"a":1,"b":2}'],
+    'ltsv' => ['ltsv', "a:1\tb:2"],
+  )
+  def test_format_with_chomp_record(data)
+    formatter, expected = data
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nchomp_record true")
+    driver_run(d, [{"a"=>1,"b"=>2}])
+    assert_equal (expected + "\n").b, @server.records.first
+  end
+
+  data(
+    'json' => ['json', '{"a":1,"b":2}'],
+    'ltsv' => ['ltsv', "a:1\tb:2"],
+  )
+  def test_format_with_chomp_record_without_append_new_line(data)
+    formatter, expected = data
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nchomp_record true\nappend_new_line false")
+    driver_run(d, [{"a"=>1,"b"=>2}])
+    assert_equal expected, @server.records.first
   end
 
   def test_data_key
@@ -173,7 +195,7 @@ class KinesisFirehoseOutputTest < Test::Unit::TestCase
     record = {"a" => "てすと"}
     driver_run(d, [record])
     assert_equal 0, d.instance.log.out.logs.size
-    assert_equal ("#{record.to_json}\n" + "\n").b, @server.records.first
+    assert_equal record.to_json.b + "\n", @server.records.first
   end
 
   def test_record_count

--- a/test/plugin/test_out_kinesis_streams.rb
+++ b/test/plugin/test_out_kinesis_streams.rb
@@ -78,7 +78,7 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal expected, @server.records.first
+    assert_equal expected + "\n", @server.records.first
   end
 
   def test_partition_key_not_found
@@ -151,7 +151,7 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
     record = {"a" => "てすと"}
     driver_run(d, [record])
     assert_equal 0, d.instance.log.out.logs.size
-    assert_equal record.to_json.b, @server.records.first
+    assert_equal (record.to_json + "\n").b, @server.records.first 
   end
 
   def test_record_count

--- a/test/plugin/test_out_kinesis_streams.rb
+++ b/test/plugin/test_out_kinesis_streams.rb
@@ -81,6 +81,17 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
     assert_equal expected + "\n", @server.records.first
   end
 
+  data(
+    'json' => ['json', '{"a":1,"b":2}'],
+    'ltsv' => ['ltsv', "a:1\tb:2"],
+  )
+  def test_format_with_chomp_record(data)
+    formatter, expected = data
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nchomp_record true")
+    driver_run(d, [{"a"=>1,"b"=>2}])
+    assert_equal expected, @server.records.first
+  end
+
   def test_partition_key_not_found
     d = create_driver(default_config + "partition_key partition_key")
     driver_run(d, [{"a"=>1}])
@@ -151,7 +162,7 @@ class KinesisStreamsOutputTest < Test::Unit::TestCase
     record = {"a" => "てすと"}
     driver_run(d, [record])
     assert_equal 0, d.instance.log.out.logs.size
-    assert_equal (record.to_json + "\n").b, @server.records.first 
+    assert_equal (record.to_json + "\n").b, @server.records.first
   end
 
   def test_record_count

--- a/test/plugin/test_out_kinesis_streams_aggregated.rb
+++ b/test/plugin/test_out_kinesis_streams_aggregated.rb
@@ -82,6 +82,17 @@ class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
     assert_equal (expected + "\n").b, @server.records.first
   end
 
+  data(
+    'json' => ['json', '{"a":1,"b":2}'],
+    'ltsv' => ['ltsv', "a:1\tb:2"],
+  )
+  def test_format_with_chomp_record(data)
+    formatter, expected = data
+    d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>\nchomp_record true")
+    driver_run(d, [{"a"=>1,"b"=>2}])
+    assert_equal expected.b, @server.records.first
+  end
+
   def test_data_key
     d = create_driver(default_config + "data_key a")
     driver_run(d, [{"a"=>1,"b"=>2}, {"b"=>2}])

--- a/test/plugin/test_out_kinesis_streams_aggregated.rb
+++ b/test/plugin/test_out_kinesis_streams_aggregated.rb
@@ -79,7 +79,7 @@ class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
     formatter, expected = data
     d = create_driver(default_config + "<format>\n@type #{formatter}\n</format>")
     driver_run(d, [{"a"=>1,"b"=>2}])
-    assert_equal expected, @server.records.first
+    assert_equal (expected + "\n").b, @server.records.first
   end
 
   def test_data_key
@@ -172,7 +172,7 @@ class KinesisStreamsOutputAggregatedTest < Test::Unit::TestCase
     record = {"a" => "てすと"}
     driver_run(d, [record])
     assert_equal 0, d.instance.log.out.logs.size
-    assert_equal record.to_json.b, @server.records.first
+    assert_equal (record.to_json + "\n").b, @server.records.first
   end
 
   data(


### PR DESCRIPTION
*Issue #, if available:*
#142 #144 

*Description of changes:*
Remove chomp from internal formatter (merge #144) and add chomp_record option for compatible format with plugin v2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.