### PR TITLE
Update api.rb

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/api.rb
+++ b/lib/fluent/plugin/kinesis_helper/api.rb
@@ -79,7 +79,7 @@ module Fluent
                 yield(batch, size)
                 batch = []
                 size = 0
-        end
+              end
               batch << record
               size += record_size
             end


### PR DESCRIPTION
Hello I am currently using the fluent-kinesis plugin for my log ingestion needs.

I was looking through the source code to better understand the buffer/batch logic within this plugin.

While looking at the source code and examining the code for split_to_batches, I noticed that the end statement for the code block checking whether the size of the batch is greater than the batch_request_max_count seems to have been misplaced.

I am not a Ruby expert, in fact I have no experience in Ruby at all, but it seems like that the end statements should be nested properly based on the depth.

Please confirm if my understanding is right and if not it is fine.

Thank you.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
