### PR TITLE
Added configuration parameter to support non-default STS API Endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Proxy url for proxying requests to amazon sts service api. This needs to be  set
 It should be added to assume_role_credentials configuration stanza in the next format:
     sts_http_proxy http://[username:password]@hostname:port
 
+**sts_endpoint_url**
+
+STS API endpoint url. This can be used to override the default global STS API endpoint of sts.amazonaws.com. Using regional endpoints may be preferred to reduce latency, and are required if utilizing a PrivateLink VPC Endpoint for STS API calls.
+
 ### instance_profile_credentials
 
 Retrieve temporary security credentials via HTTP request. This is useful on EC2 instance.

--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -128,7 +128,9 @@ module Fluent
             credentials_options[:duration_seconds] = c.duration_seconds if c.duration_seconds
             credentials_options[:external_id] = c.external_id if c.external_id
             credentials_options[:sts_endpoint_url] = c.sts_endpoint_url if c.sts_endpoint_url
-            if c.sts_http_proxy and @region
+            if c.sts_http_proxy and c.sts_endpoint_url
+                credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url)
+            elsif c.sts_http_proxy and @region
                 credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)
             elsif @region and c.sts_endpoint_url
                 credentials_options[:client] = Aws::STS::Client.new(region: @region, endpoint: c.sts_endpoint_url)
@@ -136,6 +138,8 @@ module Fluent
                 credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy)
             elsif c.sts_endpoint_url
                 credentials_options[:client] = Aws::STS::Client.new(endpoint: c.sts_endpoint_url)
+            elsif @region
+                credentials_options[:client] = Aws::STS::Client.new(region: @region)
             end
             options[:credentials] = Aws::AssumeRoleCredentials.new(credentials_options)
           when @instance_profile_credentials


### PR DESCRIPTION

Added a configuration parameter to allow for the user to define a non-default STS API endpoint. This will allow users to specify regional or custom STS endpoints. Regional STS endpoint usage is required when interfacing with STS via a PrivateLink VPC endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
