### PR TITLE
Update to v3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile.td-agent-3.3.0
+  - gemfiles/Gemfile.td-agent-3.5.0
 
 # Test with supported td-agent versions
 # https://support.treasuredata.com/hc/en-us/articles/360001479187-The-td-agent-ChangeLog
@@ -12,6 +12,8 @@ matrix:
   include:
     - rvm: 2.4.1
       gemfile: gemfiles/Gemfile.fluentd-0.14.10
+    - rvm: 2.4.2 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.0/config/projects/td-agent3.rb#L20
+      gemfile: gemfiles/Gemfile.td-agent-3.1.0
     - rvm: 2.4.2 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.1/config/projects/td-agent3.rb#L17
       gemfile: gemfiles/Gemfile.td-agent-3.1.1
     - rvm: 2.4.4 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.2.0/config/projects/td-agent3.rb#L22
@@ -20,6 +22,10 @@ matrix:
       gemfile: gemfiles/Gemfile.td-agent-3.2.1
     - rvm: 2.4.5 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.3.0/config/projects/td-agent3.rb#L22
       gemfile: gemfiles/Gemfile.td-agent-3.3.0
+    - rvm: 2.4.6 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.4.1/config/projects/td-agent3.rb#L22
+      gemfile: gemfiles/Gemfile.td-agent-3.4.1
+    - rvm: 2.4.6 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.5.0/config/projects/td-agent3.rb#L22
+      gemfile: gemfiles/Gemfile.td-agent-3.5.0
   fast_finish: true
 
 script: bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 3.2.0
+
+- Feature - Add placeholder support for stream names to send records to multiple streams : [#165](https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/165) [#174](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/174)
+- Enhancement - Add sts_endpoint_url configuration parameter to support AWS STS regional endpoints : [#186](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/186)
+- Enhancement - Add aws_ses_token configuration parameter to use IAM with MFA and directly provided temporary credentials : [#166](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/166)
+- Dependency - Update gem dependency to Ruby 2.3.0+ and Fluentd 0.14.22+
+- Bug - Fix dependency problem on AWS SDK with td-agent v3.4.1
+
 ## 3.1.0
 
 - Feature - Add process_credentials configuration : [#178](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/178)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or you can install this plugin for [td-agent][td-agent] as:
 
     td-agent-gem install fluent-plugin-kinesis
 
-If you would like to build by yourself and install, please see the section below. Your need [bundler][bundler] for this.
+If you would like to build by yourself and install, see the section below. Your need [bundler][bundler] for this.
 
 In case of using with Fluentd: Fluentd will be also installed via the process below.
 
@@ -370,30 +370,30 @@ Here are `kinesis_streams` specific configurations.
 
 ### stream_name
 Name of the stream to put data.
-As of Fluentd v1, we can handle built-in placeholders.
-Now, this parameter is supported built-in placeholders.
+
+As of Fluentd v1, built-in placeholders are supported. Now, you can also use built-in placeholders for this parameter.
 
 **NOTE:**
-Built-in placeholders request to include target key information with buffer attributes.
+Built-in placeholders require target key information in your buffer section attributes.
 
 e.g.)
 
-If you specify the following `stream_name` configuration with built-in placeholder:
+When you specify the following `stream_name` configuration with built-in placeholder:
 
 ```aconf
-stream_name "${$.kubernetes.annotations.kinesis_stream}"
+stream_name "${$.kubernetes.annotations.kinesis_streams}"
 ```
 
-You ought to specify the corresponding attributes in buffer directive:
+you ought to specify the corresponding attributes in buffer section:
 
 ```aconf
-# $.kubernetes.annotations.kinesis_stream is needed to set in buffer attributes
-<buffer $.kubernetes.annotations.kinesis_stream>
+# $.kubernetes.annotations.kinesis_streams needs to be set in buffer attributes
+<buffer $.kubernetes.annotations.kinesis_streams>
    # ...
 </buffer>
 ```
 
-In more detail, please refer [the Placeholders section in the official Fluentd](https://docs.fluentd.org/configuration/buffer-section#placeholders).
+For more details, refer [Placeholders section in the official Fluentd document](https://docs.fluentd.org/configuration/buffer-section#placeholders).
 
 ### partition_key
 A key to extract partition key from JSON object. Default `nil`, which means partition key will be generated randomly.
@@ -413,30 +413,30 @@ Here are `kinesis_streams_aggregated` specific configurations.
 
 ### stream_name
 Name of the stream to put data.
-As of Fluentd v1, we can handle built-in placeholders.
-Now, this parameter is supported built-in placeholders.
+
+As of Fluentd v1, built-in placeholders are supported. Now, you can also use built-in placeholders for this parameter.
 
 **NOTE:**
-Built-in placeholders request to include target key information with buffer attributes.
+Built-in placeholders require target key information in your buffer section attributes.
 
 e.g.)
 
-If you specify the following `stream_name` configuration with built-in placeholder:
+When you specify the following `stream_name` configuration with built-in placeholder:
 
 ```aconf
-stream_name "${$.kubernetes.annotations.kinesis_stream_aggregated}"
+stream_name "${$.kubernetes.annotations.kinesis_streams_aggregated}"
 ```
 
-You ought to specify the corresponding attributes in buffer directive:
+you ought to specify the corresponding attributes in buffer section:
 
 ```aconf
-# $.kubernetes.annotations.kinesis_stream_aggregated is needed to set in buffer attributes
-<buffer $.kubernetes.annotations.kinesis_stream_aggregated>
+# $.kubernetes.annotations.kinesis_streams_aggregated needs to be set in buffer attributes
+<buffer $.kubernetes.annotations.kinesis_streams_aggregated>
    # ...
 </buffer>
 ```
-In more detail, please refer [the Placeholders section in the official Fluentd](https://docs.fluentd.org/configuration/buffer-section#placeholders).
 
+For more details, refer [Placeholders section in the official Fluentd document](https://docs.fluentd.org/configuration/buffer-section#placeholders).
 
 ### fixed_partition_key
 A value of fixed partition key. Default `nil`, which means partition key will be generated randomly.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or just download specify your Ruby library path. Below is the sample for specify
     export RUBYLIB=$RUBYLIB:/path/to/aws-fluent-plugin-kinesis/lib
 
 ## Dependencies
- * Ruby 2.1.0+
+ * Ruby 2.3.0+
  * Fluentd 0.14.10+
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gitter](https://badges.gitter.im/awslabs/aws-fluent-plugin-kinesis.svg)](https://gitter.im/awslabs/aws-fluent-plugin-kinesis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/awslabs/aws-fluent-plugin-kinesis.svg?branch=master)](https://travis-ci.org/awslabs/aws-fluent-plugin-kinesis)
 [![Gem Version](https://badge.fury.io/rb/fluent-plugin-kinesis.svg)](https://rubygems.org/gems/fluent-plugin-kinesis)
+[![Gem Downloads](https://img.shields.io/gem/dt/fluent-plugin-kinesis.svg)](https://rubygems.org/gems/fluent-plugin-kinesis)
 
 [Fluentd][fluentd] output plugin
 that sends events to [Amazon Kinesis Data Streams][streams] and [Amazon Kinesis Data Firehose][firehose]. Also it supports [KPL Aggregated Record Format][kpl]. This gem includes three output plugins respectively:

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency "fluentd", ">= 0.14.10", "< 2"
 

--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -40,12 +40,20 @@ Gem::Specification.new do |spec|
   #   NoMethodError: undefined method `event=' for #<Seahorse::Model::Shapes::ShapeRef:*>
   #   https://github.com/aws/aws-sdk-ruby/commit/03d60f9d3d821e645bd2a3efca066f37350ef906#diff-c69f15af8ea3eb9ab152659476e04608R401
   #   https://github.com/aws/aws-sdk-ruby/commit/571c2d0e5ff9c24ff72893a08a74790db591fb57#diff-a55155f04aa6559460a0814e264eb0cdR43
-  spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5"
+  # Exclude aws-sdk-kinesis v1.14 to avoid aws-sdk-core dependency problem with td-agent v3.4.1
+  #   LoadError: cannot load such file -- aws-sdk-core/plugins/transfer_encoding.rb
+  #   https://github.com/aws/aws-sdk-ruby/commit/bb61ed0a2fabc6b1f90b757f13f37d5aeae48d8a#diff-b493e941d32289cd2df7eebc3fc5be2cR26
+  #   https://github.com/aws/aws-sdk-ruby/commit/e26577d2a426a4be79cd2d9edc1a4a4176e388ba#diff-10f50e27b30c3dc522b3c25db5782e2e
+  spec.add_dependency "aws-sdk-kinesis", "~> 1", "!= 1.4", "!= 1.5", "!= 1.14"
   # Exclude aws-sdk-firehose v1.9 to avoid aws-sdk-core dependency problem with td-agent v3.2.1
   #   LoadError: cannot load such file -- aws-sdk-core/plugins/endpoint_discovery.rb
   #   https://github.com/aws/aws-sdk-ruby/commit/85d8538a62255e58d9e176ee524a9f94354b51a0#diff-d51486091a10ada65b308b7f45966af1R18
   #   https://github.com/aws/aws-sdk-ruby/commit/7c9584bc6473100df9aec9333ab491ad4faeeca8#diff-be94f87e58e00329a6c0e03e43d5c292
-  spec.add_dependency "aws-sdk-firehose", "~> 1", "!= 1.5", "!= 1.9"
+  # Exclude aws-sdk-firehose v1.15 to avoid aws-sdk-core dependency problem with td-agent v3.4.1
+  #   LoadError: cannot load such file -- aws-sdk-core/plugins/transfer_encoding.rb
+  #   https://github.com/aws/aws-sdk-ruby/commit/bb61ed0a2fabc6b1f90b757f13f37d5aeae48d8a#diff-d51486091a10ada65b308b7f45966af1R26
+  #   https://github.com/aws/aws-sdk-ruby/commit/e26577d2a426a4be79cd2d9edc1a4a4176e388ba#diff-10f50e27b30c3dc522b3c25db5782e2e
+  spec.add_dependency "aws-sdk-firehose", "~> 1", "!= 1.5", "!= 1.9", "!= 1.15"
 
   spec.add_dependency "google-protobuf", "~> 3"
 

--- a/gemfiles/Gemfile.td-agent-3.1.0
+++ b/gemfiles/Gemfile.td-agent-3.1.0
@@ -1,0 +1,31 @@
+#
+# Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
+gemspec path: ".."
+
+# Specify related gems for td-agent v3.1.0
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.0/config/projects/td-agent3.rb#L25
+gem "fluentd", "0.14.25"
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.0/plugin_gems.rb#L16-L23
+gem "jmespath", "1.3.1"
+gem "aws-partitions", "1.42.0"
+gem "aws-sigv4", "1.0.2"
+gem "aws-sdk-core", "3.11.0"
+gem "aws-sdk-kms", "1.3.0"
+gem "aws-sdk-sqs", "1.3.0"
+gem "aws-sdk-s3", "1.8.0"
+gem "fluent-plugin-s3", "1.1.0"

--- a/gemfiles/Gemfile.td-agent-3.4.1
+++ b/gemfiles/Gemfile.td-agent-3.4.1
@@ -1,0 +1,34 @@
+#
+# Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
+gemspec path: ".."
+
+# Specify related gems for td-agent v3.4.1
+# td-agent v3.4.0 has the same dependencies
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.4.1/config/projects/td-agent3.rb#L27
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.4.0/config/projects/td-agent3.rb#L27
+gem "fluentd", "1.4.2"
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.4.1/plugin_gems.rb#L16-L23
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.4.0/plugin_gems.rb#L16-L23
+gem "jmespath", "1.4.0"
+gem "aws-partitions", "1.149.0"
+gem "aws-sigv4", "1.1.0"
+gem "aws-sdk-core", "3.48.3"
+gem "aws-sdk-kms", "1.16.0"
+gem "aws-sdk-sqs", "1.13.0"
+gem "aws-sdk-s3", "1.36.0"
+gem "fluent-plugin-s3", "1.1.9"

--- a/gemfiles/Gemfile.td-agent-3.5.0
+++ b/gemfiles/Gemfile.td-agent-3.5.0
@@ -1,0 +1,31 @@
+#
+# Copyright 2014-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
+gemspec path: ".."
+
+# Specify related gems for td-agent v3.5.0
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.5.0/config/projects/td-agent3.rb#L27
+gem "fluentd", "1.7.0"
+# https://github.com/treasure-data/omnibus-td-agent/blob/v3.5.0/plugin_gems.rb#L16-L23
+gem "jmespath", "1.4.0"
+gem "aws-partitions", "1.195.0"
+gem "aws-sigv4", "1.1.0"
+gem "aws-sdk-core", "3.61.2"
+gem "aws-sdk-kms", "1.24.0"
+gem "aws-sdk-sqs", "1.20.0"
+gem "aws-sdk-s3", "1.46.0"
+gem "fluent-plugin-s3", "1.1.11"

--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -21,15 +21,15 @@ module Fluent
       module Client
         module ClientParams
           include Fluent::Configurable
-          config_param :region, :string,  default: nil
+          config_param :region,          :string,  default: nil
 
           config_param :http_proxy,      :string, default: nil, secret: true
           config_param :endpoint,        :string, default: nil
           config_param :ssl_verify_peer, :bool,   default: true
 
-          config_param :aws_key_id,  :string, default: nil, secret: true
-          config_param :aws_sec_key, :string, default: nil, secret: true
-          config_param :aws_ses_token, :string, default: nil, secret: true
+          config_param :aws_key_id,      :string, default: nil, secret: true
+          config_param :aws_sec_key,     :string, default: nil, secret: true
+          config_param :aws_ses_token,   :string, default: nil, secret: true
           config_section :assume_role_credentials, multi: false do
             desc "The Amazon Resource Name (ARN) of the role to assume"
             config_param :role_arn, :string, secret: true
@@ -135,7 +135,7 @@ module Fluent
             credentials_options[:sts_endpoint_url] = c.sts_endpoint_url if c.sts_endpoint_url
             if c.sts_http_proxy and c.sts_endpoint_url
                 credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url)
-            elsif c.sts_http_proxy and @region
+            elsif @region and c.sts_http_proxy
                 credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)
             elsif @region and c.sts_endpoint_url
                 credentials_options[:client] = Aws::STS::Client.new(region: @region, endpoint: c.sts_endpoint_url)

--- a/lib/fluent_plugin_kinesis/version.rb
+++ b/lib/fluent_plugin_kinesis/version.rb
@@ -13,5 +13,5 @@
 # language governing permissions and limitations under the License.
 
 module FluentPluginKinesis
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
*Description of changes:*

## 3.2.0

- Feature - Add placeholder support for stream names to send records to multiple streams : [#165](https://github.com/awslabs/aws-fluent-plugin-kinesis/issues/165) [#174](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/174)
- Enhancement - Add sts_endpoint_url configuration parameter to support AWS STS regional endpoints : [#186](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/186)
- Enhancement - Add aws_ses_token configuration parameter to use IAM with MFA and directly provided temporary credentials : [#166](https://github.com/awslabs/aws-fluent-plugin-kinesis/pull/166)
- Dependency - Update gem dependency to Ruby 2.3.0+ and Fluentd 0.14.22+
- Bug - Fix dependency problem on AWS SDK with td-agent v3.4.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
