### PR TITLE
Use Fluent::MessagePackFactory class methods instead of Mixin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ gemfile:
 # https://support.treasuredata.com/hc/en-us/articles/360001479187-The-td-agent-ChangeLog
 matrix:
   include:
+    - rvm: 2.6.5
+      gemfile: gemfiles/Gemfile.fluentd-1.9.1 # Latest Fluentd
     - rvm: 2.4.1
-      gemfile: gemfiles/Gemfile.fluentd-0.14.22
+      gemfile: gemfiles/Gemfile.fluentd-0.14.22 # Oldest supported Fluentd
     - rvm: 2.4.2 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.0/config/projects/td-agent3.rb#L20
       gemfile: gemfiles/Gemfile.td-agent-3.1.0
     - rvm: 2.4.2 # https://github.com/treasure-data/omnibus-td-agent/blob/v3.1.1/config/projects/td-agent3.rb#L17

--- a/gemfiles/Gemfile.fluentd-1.9.1
+++ b/gemfiles/Gemfile.fluentd-1.9.1
@@ -1,0 +1,20 @@
+#
+# Copyright 2014-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-kinesis.gemspec
+gemspec path: ".."
+
+gem "fluentd", "1.9.1"

--- a/lib/fluent/plugin/kinesis.rb
+++ b/lib/fluent/plugin/kinesis.rb
@@ -12,6 +12,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require 'fluent/version'
+require 'fluent/msgpack_factory'
 require 'fluent/plugin/output'
 require 'fluent/plugin/kinesis_helper/client'
 require 'fluent/plugin/kinesis_helper/api'
@@ -20,7 +22,6 @@ require 'zlib'
 module Fluent
   module Plugin
     class KinesisOutput < Fluent::Plugin::Output
-      include Fluent::MessagePackFactory::Mixin
       include KinesisHelper::Client
       include KinesisHelper::API
 
@@ -131,6 +132,14 @@ module Fluent
       rescue SkipRecordError => e
         log.error(truncate e)
         ''
+      end
+
+      if Gem::Version.new(Fluent::VERSION) >= Gem::Version.new('1.8.0')
+        def msgpack_unpacker(*args)
+          Fluent::MessagePackFactory.msgpack_unpacker(*args)
+        end
+      else
+        include Fluent::MessagePackFactory::Mixin
       end
 
       def write_records_batch(chunk, &block)


### PR DESCRIPTION
*Issue #, if available:*
#194 

*Description of changes:*
Use Fluent::MessagePackFactory class methods with Fluentd v1.8+ instead of deprecated Mixin methods.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
