### PR TITLE
add elsif statement for region && c.sts_http_proxy && c.sts_endpoint_url

### DIFF
--- a/lib/fluent/plugin/kinesis_helper/client.rb
+++ b/lib/fluent/plugin/kinesis_helper/client.rb
@@ -133,7 +133,9 @@ module Fluent
             credentials_options[:duration_seconds] = c.duration_seconds if c.duration_seconds
             credentials_options[:external_id] = c.external_id if c.external_id
             credentials_options[:sts_endpoint_url] = c.sts_endpoint_url if c.sts_endpoint_url
-            if c.sts_http_proxy and c.sts_endpoint_url
+            if @region and c.sts_http_proxy and c.sts_endpoint_url
+                credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url)
+            elsif c.sts_http_proxy and c.sts_endpoint_url
                 credentials_options[:client] = Aws::STS::Client.new(http_proxy: c.sts_http_proxy, endpoint: c.sts_endpoint_url)
             elsif @region and c.sts_http_proxy
                 credentials_options[:client] = Aws::STS::Client.new(region: @region, http_proxy: c.sts_http_proxy)


### PR DESCRIPTION
caused by below exception

```
2020-03-16 23:14:09 +0900 [warn]: #1 got unrecoverable error in primary and no secondary error_class=Aws::Errors::MissingRegionError error="missing region; use :region option or export region name to ENV['AWS_REGION']"
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/aws-sdk-core/plugins/regional_endpoint.rb:51:in `after_initialize'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/seahorse/client/base.rb:78:in `block in after_initialize'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/seahorse/client/base.rb:77:in `each'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/seahorse/client/base.rb:77:in `after_initialize'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/seahorse/client/base.rb:21:in `initialize'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/aws-sdk-sts/client.rb:310:in `initialize'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/aws-sdk-core-3.91.0/lib/seahorse/client/base.rb:99:in `new'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis_helper/client.rb:137:in `setup_credentials'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis_helper/client.rb:102:in `client_options'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis_helper/client.rb:85:in `client'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/out_kinesis_firehose.rb:51:in `block in write'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis_helper/api.rb:91:in `batch_request_with_retry'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis.rb:151:in `block (2 levels) in write_records_batch'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis_helper/api.rb:86:in `split_to_batches'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis.rb:149:in `block in write_records_batch'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin/buffer/memory_chunk.rb:81:in `open'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin/buffer/memory_chunk.rb:81:in `open'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/kinesis.rb:147:in `write_records_batch'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-kinesis-3.2.1/lib/fluent/plugin/out_kinesis_firehose.rb:47:in `write'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin/output.rb:1122:in `try_flush'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin/output.rb:1428:in `flush_thread_run'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin/output.rb:458:in `block (2 levels) in start'
  2020-03-16 23:14:09 +0900 [warn]: #1 /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluentd-1.7.0/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```

with fluentd config

```
      @type "kinesis_firehose"
      region "ap-northeast-2"
      http_proxy xxxxxx
      delivery_stream_name "xxxxxx"
```

Signed-off-by: JiHyunSong <jihyun.song0829@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
