### PR TITLE
Adding Stream name to debug logs

### DIFF
--- a/lib/fluent/plugin/kinesis.rb
+++ b/lib/fluent/plugin/kinesis.rb
@@ -146,13 +146,13 @@ module Fluent
         include Fluent::MessagePackFactory::Mixin
       end
 
-      def write_records_batch(chunk, &block)
+      def write_records_batch(chunk, stream_name, &block)
         unique_id = chunk.dump_unique_id_hex(chunk.unique_id)
         records = chunk.to_enum(:msgpack_each)
         split_to_batches(records) do |batch, size|
-          log.debug(sprintf "Write chunk %s / %3d records / %4d KB", unique_id, batch.size, size/1024)
+          log.debug(sprintf "%s: Write chunk %s / %3d records / %4d KB", stream_name, unique_id, batch.size, size/1024)
           batch_request_with_retry(batch, &block)
-          log.debug("Finish writing chunk")
+          log.debug(sprintf "%s: Finish writing chunk", stream_name)
         end
       end
 

--- a/lib/fluent/plugin/out_kinesis_firehose.rb
+++ b/lib/fluent/plugin/out_kinesis_firehose.rb
@@ -45,7 +45,7 @@ module Fluent
 
       def write(chunk)
         delivery_stream_name = extract_placeholders(@delivery_stream_name, chunk)
-        write_records_batch(chunk) do |batch|
+        write_records_batch(chunk, delivery_stream_name) do |batch|
           records = batch.map{|(data)|
             { data: data }
           }

--- a/lib/fluent/plugin/out_kinesis_streams.rb
+++ b/lib/fluent/plugin/out_kinesis_streams.rb
@@ -42,7 +42,7 @@ module Fluent
 
       def write(chunk)
         stream_name = extract_placeholders(@stream_name, chunk)
-        write_records_batch(chunk) do |batch|
+        write_records_batch(chunk, stream_name) do |batch|
           records = batch.map{|(data, partition_key)|
             { data: data, partition_key: partition_key }
           }

--- a/lib/fluent/plugin/out_kinesis_streams_aggregated.rb
+++ b/lib/fluent/plugin/out_kinesis_streams_aggregated.rb
@@ -44,7 +44,7 @@ module Fluent
 
       def write(chunk)
         stream_name = extract_placeholders(@stream_name, chunk)
-        write_records_batch(chunk) do |batch|
+        write_records_batch(chunk, stream_name) do |batch|
           key = @partition_key_generator.call
           records = batch.map{|(data)|data}
           client.put_records(


### PR DESCRIPTION
*Issue #, if available:*

Cannot identify Stream name in debug logs.

When dealing with multiple kinesis outputs, the debug logs don't contain information about which stream has written the chunks.

*Description of changes:*

Feed the write_records_batch function with stream name.
Edit calls for the three kinesis outputs with stream name.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
