### PR TITLE
Adjust aws-sdk-firehose dependency in fluent-plugin-kinesis.gemspec

### DIFF
--- a/fluent-plugin-kinesis.gemspec
+++ b/fluent-plugin-kinesis.gemspec
@@ -53,7 +53,9 @@ Gem::Specification.new do |spec|
   #   LoadError: cannot load such file -- aws-sdk-core/plugins/transfer_encoding.rb
   #   https://github.com/aws/aws-sdk-ruby/commit/bb61ed0a2fabc6b1f90b757f13f37d5aeae48d8a#diff-d51486091a10ada65b308b7f45966af1R26
   #   https://github.com/aws/aws-sdk-ruby/commit/e26577d2a426a4be79cd2d9edc1a4a4176e388ba#diff-10f50e27b30c3dc522b3c25db5782e2e
-  spec.add_dependency "aws-sdk-firehose", "~> 1", "!= 1.5", "!= 1.9", "!= 1.15"
+  # Exlude aws-sdk-firehose from the v1.59 to avoid fluent-plugin-kinesis dependency problem with aws-sdk-core v3.188.0 and aws-event-stream v1.3.0 which are dependency of this aws-sdk-firehose
+  #   aws-sdk-core v3.188.0 and aws-eventstream v1.3.0 boths requires Ruby version >= 2.5 and it conflict with fluent-plugin-kinesis's required ruby version, 2.3.
+  spec.add_dependency "aws-sdk-firehose", "~> 1", "< 1.59", "!= 1.5", "!= 1.9", "!= 1.15"
 
   spec.add_dependency "google-protobuf", "~> 3"
 

--- a/gemfiles/Gemfile.td-agent-3.3.0
+++ b/gemfiles/Gemfile.td-agent-3.3.0
@@ -16,8 +16,9 @@ gem "aws-sdk-sqs", "1.10.0"
 gem "aws-sdk-s3", "1.30.0"
 gem "fluent-plugin-s3", "1.1.7"
 
-# google-protobuf 3.19.2 requires Ruby 2.5+
+# google-protobuf 3.19.2 and aws-eventstream 1.13.0 requires Ruby 2.5+
 # https://rubygems.org/gems/google-protobuf/versions/3.19.2-x86_64-linux
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.5")
   gem "google-protobuf", "< 3.19.2"
+  gem "aws-eventstream", "< 1.13.0"
 end


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:
## Summary

This PR adjusts the `aws-sdk-firehose` dependency in the `fluent-plugin-kinesis.gemspec` file to mitigate a conflict with `aws-sdk-core v3.188.0` and `aws-event-stream v1.3.0`. The new dependency range `< 1.59` is introduced to address compatibility issues.

## Changes Made

- Adjusted `aws-sdk-firehose` dependency in `fluent-plugin-kinesis.gemspec`.

## Additional Notes

Excluded `aws-sdk-firehose` from version `1.59` to avoid a dependency problem with `aws-sdk-core v3.188.0` and `aws-event-stream v1.3.0`, both of which require Ruby version >= 2.5, conflicting with the required Ruby version of `fluent-plugin-kinesis` (2.3).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
