### PR TITLE
Correcting td-agent-gem install command and fluent-gem install command addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ If you would like to build by yourself and install, you can build and install as
 If using td-agent v4 or lower, use td-agent-gem
     $ td-agent-gem install fluent-plugin-kinesis
 
+If using fluent-package v5 or higher, use fluent-gem
+    $ fluent-gem install fluent-plugin-kinesis
+
 ## Requirements
 
 | fluent-plugin-kinesis | fluentd    | ruby     |

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ If you would like to build by yourself and install, you can build and install as
     $ bundle exec rake build
     $ bundle exec rake install
 
-If using td-agent v4 or lower, use td-agent-gem
+If using td-agent v4 or lower, use td-agent-gem:
+
     $ td-agent-gem install fluent-plugin-kinesis
 
-If using fluent-package v5 or higher, use fluent-gem
+If using fluent-package v5 or higher, use fluent-gem:
+
     $ fluent-gem install fluent-plugin-kinesis
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ If you would like to build by yourself and install, you can build and install as
     $ bundle exec rake build
     $ bundle exec rake install
 
-    # If using fluent-package (td-agent), use td-agent-gem
-    $ td-agent-gem install pkg/fluent-plugin-kinesis
+If using td-agent v4 or lower, use td-agent-gem
+    $ td-agent-gem install fluent-plugin-kinesis
 
 ## Requirements
 


### PR DESCRIPTION
*Issue #, if available:*
td-agent is no longer maintained, as its released under the fluent-package name, that changes the install command since the first version of fluent-package (v5).

*Description of changes:*
This MR is meant to:
- correct the gem package name for td-agent
- correct the td-agent install description
- add the correct fluent-package install command

Previously the file, stated that fluent-package and td-agent are using the same install command, however that is not the case, explained [here](https://docs.fluentd.org/quickstart/fluent-package-v5-vs-td-agent) and [here](https://github.com/fluent/fluent-package-builder/blob/master/CHANGELOG.md#release-v500---20230728).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
